### PR TITLE
Add libvirt exporter service

### DIFF
--- a/openstack_hypervisor/api.py
+++ b/openstack_hypervisor/api.py
@@ -32,6 +32,7 @@ MAPPING = {
     "node": model.NodeConfig,
     "logging": model.LoggingConfig,
     "telemetry": model.TelemetryConfig,
+    "monitoring": model.MonitoringConfig,
 }
 
 
@@ -143,6 +144,12 @@ async def update_logging(config: model.LoggingConfig):
 async def update_telemetry(config: model.TelemetryConfig):
     """Updates telemetry section settings."""
     return _update_settings("telemetry", config)
+
+
+@app.patch("/settings/monitoring")
+async def update_monitoring(config: model.MonitoringConfig):
+    """Updates monitoring section settings."""
+    return _update_settings("monitoring", config)
 
 
 @app.post("/reset")

--- a/openstack_hypervisor/model.py
+++ b/openstack_hypervisor/model.py
@@ -110,3 +110,9 @@ class TelemetryConfig(BaseModel):
 
     enable: bool = Field(default=False)
     publisher_secret: Optional[str] = Field(alias="publisher-secret")
+
+
+class MonitoringConfig(BaseModel):
+    """Data model for the monitoring configuration settings."""
+
+    enable: bool = Field(default=False)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -266,7 +266,7 @@ apps:
     daemon: simple
     install-mode: disable
     restart-condition: on-abnormal
-    command: 'bin/libvirt-exporter'
+    command: 'bin/libvirt-exporter --web.listen-address :9177 --web.telemetry-path /metrics --libvirt.uri qemu:///system'
     plugs:
       - libvirt
       - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -261,6 +261,17 @@ apps:
         listen-stream: $SNAP_DATA/run/hypervisor-config/unix.socket
         socket-mode: 0666
 
+  # Exporters
+  libvirt-exporter:
+    daemon: simple
+    install-mode: disable
+    restart-condition: on-abnormal
+    command: 'bin/libvirt-exporter'
+    plugs:
+      - libvirt
+      - network-bind
+
+
 parts:
   kvm-support:
     plugin: nil
@@ -585,6 +596,26 @@ parts:
     override-build: |
       craftctl default
       snap-helpers write-hooks
+
+  libvirt-exporter:
+    plugin: go
+    source-tag: 2.3.3
+    source-type: git
+    source: https://github.com/Tinkoff/libvirt-exporter
+    build-snaps:
+      - go
+    after:
+      - libvirt
+    build-packages:
+      - pkg-config
+      - libvirt-dev
+    stage-packages:
+      - libdb5.3
+    override-prime: |
+      craftctl default
+      # Drop the driver for Xen introduced by libvirt-dev, it will cause
+      # libvirt failed to start.
+      rm -rf $CRAFT_PRIME/usr/lib/libvirt/connection-driver/libvirt_driver_libxl.so
 
 slots:
   hypervisor-config:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -606,16 +606,9 @@ parts:
       - go
     after:
       - libvirt
-    build-packages:
-      - pkg-config
-      - libvirt-dev
-    stage-packages:
-      - libdb5.3
-    override-prime: |
-      craftctl default
-      # Drop the driver for Xen introduced by libvirt-dev, it will cause
-      # libvirt failed to start.
-      rm -rf $CRAFT_PRIME/usr/lib/libvirt/connection-driver/libvirt_driver_libxl.so
+    build-environment:
+      - CGO_CFLAGS: "-I$CRAFT_STAGE/usr/include"
+      - CGO_LDFLAGS: "-L$CRAFT_STAGE/usr/lib"
 
 slots:
   hypervisor-config:


### PR DESCRIPTION
As part of the COS integration, this PR adds the [libvirt exporter](https://github.com/Tinkoff/libvirt-exporter/tree/master) service to the snap, and also add snap configuration option to enable / disable exporter services. By default, the exporter services are disabled until the monitoring.enable is set to true.

Related to: https://review.opendev.org/c/openstack/charm-openstack-hypervisor/+/893007
PR Migrated from https://github.com/openstack-snaps/snap-openstack-hypervisor/pull/32