### PR TITLE
Use rabbit quorum queues for ceilometer

### DIFF
--- a/templates/ceilometer.conf.j2
+++ b/templates/ceilometer.conf.j2
@@ -50,3 +50,6 @@ user_domain_id = {{ identity.user_domain_id }}
 project_name = {{ identity.project_name }}
 username = {{ identity.username }}
 password = {{ identity.password }}
+
+[oslo_messaging_rabbit]
+rabbit_quorum_queue = True

--- a/templates/neutron.conf.j2
+++ b/templates/neutron.conf.j2
@@ -63,3 +63,6 @@ region_name = {{ identity.region_name }}
 project_name = {{ identity.project_name }}
 username = {{ identity.username }}
 password = {{ identity.password }}
+
+[oslo_messaging_rabbit]
+rabbit_quorum_queue = True


### PR DESCRIPTION
Use quorum queues for ceilometer-compute-agent
service. Update ceilometer.conf template with
quorum queues.
AMQP is not used by neutron-ovn-metadata-agent,
however for the completion of neutron.conf, add
quorum queues in the template.