### PR TITLE
Use rabbit quorum queues for ceilometer

### DIFF
--- a/templates/ceilometer.conf.j2
+++ b/templates/ceilometer.conf.j2
@@ -50,3 +50,6 @@ user_domain_id = {{ identity.user_domain_id }}
 project_name = {{ identity.project_name }}
 username = {{ identity.username }}
 password = {{ identity.password }}
+
+[oslo_messaging_rabbit]
+rabbit_quorum_queue = True

--- a/templates/libvirtd.conf.j2
+++ b/templates/libvirtd.conf.j2
@@ -55,7 +55,7 @@ tcp_port = "16509"
 #listen_addr = "192.168.0.1"
 
 
-# Flag toggling mDNS advertizement of the libvirt service.
+# Flag toggling mDNS advertisement of the libvirt service.
 #
 # Alternatively can disable for all services on a host by
 # stopping the Avahi daemon
@@ -63,7 +63,7 @@ tcp_port = "16509"
 # This is disabled by default, uncomment this to enable it
 #mdns_adv = 1
 
-# Override the default mDNS advertizement name. This must be
+# Override the default mDNS advertisement name. This must be
 # unique on the immediate broadcast network.
 #
 # The default is "Virtualization Host HOSTNAME", where HOSTNAME

--- a/templates/neutron.conf.j2
+++ b/templates/neutron.conf.j2
@@ -63,3 +63,6 @@ region_name = {{ identity.region_name }}
 project_name = {{ identity.project_name }}
 username = {{ identity.username }}
 password = {{ identity.password }}
+
+[oslo_messaging_rabbit]
+rabbit_quorum_queue = True


### PR DESCRIPTION
Use quorum queues for ceilometer-compute-agent
service. Update ceilometer.conf template with
quorum queues.
AMQP is not used by neutron-ovn-metadata-agent,
however for the completion of neutron.conf, add
quorum queues in the template.