### PR TITLE
Add config option spice-proxy-url

### DIFF
--- a/openstack_hypervisor/model.py
+++ b/openstack_hypervisor/model.py
@@ -72,7 +72,10 @@ class ComputeConfig(BaseModel):
     cpu_mode: str = Field(alias="cpu-mode", default="host-model")
     virt_type: str = Field(alias="virt-type", default="auto")
     cpu_models: Optional[str] = Field(alias="cpu-models")
-    spice_proxy_address: Optional[IPvAnyAddress] = Field(alias="spice-proxy-address")
+    spice_proxy_address: Optional[IPvAnyAddress] = Field(
+        alias="spice-proxy-address", deprecated="Use spice-proxy-url"
+    )
+    spice_proxy_url: Optional[AnyUrl] = Field(alias="spice-proxy-url")
     rbd_user: Optional[str] = Field(alias="rbd-user", default="nova")
     rbd_secret_uuid: Optional[str] = Field(alias="rbd-secret-uuid")
     rbd_key: Optional[str] = Field(alias="rbd-key")

--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -65,10 +65,17 @@ cafile = {{ snap_common }}/etc/ssl/certs/receive-ca-bundle.pem
 [spice]
 enabled = True
 agent_enabled = True
+{% if compute.spice_proxy_url -%}
+html5proxy_base_url = {{ compute.spice_proxy_url }}
+{% elif compute.spice_proxy_address -%}
 html5proxy_base_url = http://{{ compute.spice_proxy_address }}:6082/spice_auto.html
+{% endif -%}
 server_listen = {{ node.ip_address }}
 server_proxyclient_address = {{ node.ip_address }}
 keymap = en-us
+
+[vnc]
+enabled = False
 
 [glance]
 service_type = image


### PR DESCRIPTION
html5proxy_base_url is constructed based on spice-proxy-address with harcoded port. However with the use of loadbalancer for nova-spiceproxy, the URL may be based on name instead of ip and port can change. So add new config option spice-proxy-url in compute.
Deprecate existing config option spice-proxy-address. Disable vnc in nova.conf