### PR TITLE
Add condition on templating rabbitmq, early exit ovn if sb con missing

### DIFF
--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -624,7 +624,10 @@ def _configure_ovn_base(snap: Snap) -> None:
             "external_ids:ovn-match-northd-version=true",
         ]
     )
-    sb_conn = snap.config.get("network.ovn-sb-connection")
+    try:
+        sb_conn = snap.config.get("network.ovn-sb-connection")
+    except UnknownConfigKey:
+        sb_conn = None
     if not sb_conn:
         logging.info("OVN SB connection URL not configured, skipping.")
         return
@@ -740,6 +743,13 @@ def _configure_ovn_external_networking(snap: Snap) -> None:
     # TODO:
     # Deal with multiple external networks.
     # Deal with wiring of hardware port to each bridge.
+    try:
+        sb_conn = snap.config.get("network.ovn-sb-connection")
+    except UnknownConfigKey:
+        sb_conn = None
+    if not sb_conn:
+        logging.info("OVN SB connection URL not configured, skipping.")
+        return
     external_bridge = snap.config.get("network.external-bridge")
     physnet_name = snap.config.get("network.physnet-name")
     try:

--- a/templates/ceilometer.conf.j2
+++ b/templates/ceilometer.conf.j2
@@ -4,8 +4,10 @@
 [DEFAULT]
 debug = {{ logging.debug }}
 
+{% if rabbitmq is defined %}
 # AMQP connection to RabbitMQ
 transport_url = {{ rabbitmq.url }}
+{% endif %}
 
 [polling]
 batch_size = 50

--- a/templates/neutron.conf.j2
+++ b/templates/neutron.conf.j2
@@ -10,8 +10,10 @@ use_journal = True
 log_file = {{ snap_common }}/log/neutron.log
 debug = {{ logging.debug }}
 
+{% if rabbitmq is defined %}
 # AMQP connection to RabbitMQ
 transport_url = {{ rabbitmq.url }}
+{% endif %}
 
 {% if network.dns_domain %}
 dns_domain = {{ network.dns_domain }}

--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -17,8 +17,10 @@ debug = {{ logging.debug }}
 host = {{ node.fqdn }}
 my_ip = {{ node.ip_address }}
 
+{% if rabbitmq is defined %}
 # AMQP connection to RabbitMQ
 transport_url = {{ rabbitmq.url }}
+{% endif %}
 
 # Fix the amount of metadata workers to a sane default
 metadata_workers = 4


### PR DESCRIPTION
Add condition on templating rabbitmq since it's unset by default. Early exit ovn configuration is the SB connection string is missing.