### PR TITLE
Set a minimum version to snapd

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,6 +5,8 @@ summary: OpenStack Hypervisor
 description: |
   The OpenStack Hypervisor snap provides the requires components
   to operate a cloud hypervisor as part of an OpenStack deployment.
+assumes:
+- snapd2.61
 grade: stable
 confinement: strict
 environment:


### PR DESCRIPTION
This feature[0] was merged in 2.61, which is needed for observability. Set it as minimum requirements for the snap.

0: https://github.com/snapcore/snapd/pull/13149