### PR TITLE
Resume guest instances on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ for cpu models.
 
 IP address to use for configuration of SPICE consoles in instances.
 
+* `compute.resume-on-boot` (true) Resume instances on boot
+
+Whether to resume instances on boot or not.
+
 ### identity
 
 Configuration of options related to identity (Keystone):

--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -253,6 +253,7 @@ DEFAULT_CONFIG = {
     "compute.cert": UNSET,
     "compute.key": UNSET,
     "compute.migration-address": UNSET,
+    "compute.resume-on-boot": True,
     # Neutron
     "network.physnet-name": "physnet1",
     "network.external-bridge": "br-ex",

--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -25,6 +25,8 @@ transport_url = {{ rabbitmq.url }}
 # Fix the amount of metadata workers to a sane default
 metadata_workers = 4
 
+resume_guests_state_on_host_boot = {{ compute.resume_on_boot }}
+
 [workarounds]
 disable_rootwrap = True
 


### PR DESCRIPTION
Add the option `compute.resume-on-boot` to resume guest instances when the host boots.