### PR TITLE
fix: Remove unnessary plugins for ovs-exporter

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -283,12 +283,6 @@ apps:
     command: 'bin/ovs-exporter-service'
     plugs:
       - network-bind
-      - openvswitch
-      - log-observe
-      - system-observe
-      - network-observe
-      - netlink-audit
-      - kernel-module-observe
     daemon: simple
     install-mode: disable
 


### PR DESCRIPTION
Fix: #23 
All the required files for exporter are inside SNAP_COMMON, so those plugins are not necessary

Below two files show the required files of ovs-exporter and how we change it to files inside SNAP_COMMON:

- [Required files for exporter](https://github.com/greenpau/ovsdb/blob/ba2fa6bc5e69ee5511f72847d060e6709036ae0f/ovs.go#L42)
- [Change configuration for exporter](https://github.com/canonical/snap-openstack-hypervisor/blob/17798d125db2637a76fc54214228bd6e3a8259b2/openstack_hypervisor/services.py#L195)
