### PR TITLE
Add misc missing plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,7 +71,7 @@ apps:
   # Libvirt
   libvirtd:
     environment:
-      # overriding usr/bin path to current, to ensure the symlink to qemu-system-* is not dependent on the snap revision 
+      # overriding usr/bin path to current, to ensure the symlink to qemu-system-* is not dependent on the snap revision
       PATH: $SNAP/../current/usr/bin:$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH
     command: usr/sbin/libvirtd --pid $SNAP_DATA/libvirt.pid --listen
     daemon: simple
@@ -109,6 +109,7 @@ apps:
       - network-bind
       - network-control
       - microstack-support
+      - system-observe
   virsh:
     command: usr/bin/virsh
     plugs:
@@ -187,6 +188,7 @@ apps:
     command: usr/bin/ovs-vsctl
     plugs:
       - network
+      - network-control
       - process-control
       - microstack-support
   ovs-appctl:
@@ -205,6 +207,7 @@ apps:
     command: usr/bin/ovs-dpctl
     plugs:
       - network
+      - network-control
       - process-control
       - microstack-support
 


### PR DESCRIPTION
ovs-dpctl needs net_admin (network-control).
virtlogd wants to ptrace the libvirtd proces (system-observe).

This resolves a few of the apparmor related messages generated from this snap as well as restoring functionality for tools.