### PR TITLE
Obsolete enable-gateway config

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ and OVN:
 
 * `network.ip-address` (`node.ip-address`) IP address to use for overlay network endpoints
 * `network.ovn-sb-connection` (`tcp:127.0.0.1:6642`) OVN Southbound DB connection URL
-* `network.enable-gateway` (False) Enable OVS/OVS as north/south gateway
+* `network.enable-gateway` (False) Obsolete - gateway status determined from configuration
 
 TLS configuration for OVN can also be supplied via snap configuration:
 


### PR DESCRIPTION
Gateway status can be derived from the configuration provided for the external gateway IP address and the external NIC.

Obsolete this configuration option and derive its value instead.