### PR TITLE
[nova] Add config compute_monitors

### DIFF
--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -27,6 +27,9 @@ metadata_workers = 4
 
 resume_guests_state_on_host_boot = {{ compute.resume_on_boot }}
 
+# To collect compute node related metrics
+compute_monitors = cpu.virt_driver
+
 [workarounds]
 disable_rootwrap = True
 


### PR DESCRIPTION
Add config compute_monitors in nova.conf and set it to cpu.virt_driver.
This helps in collecting compute node related metrics `compute.node.cpu.*` [1]

[1] https://docs.openstack.org/ceilometer/2024.1/admin/telemetry-measurements.html