### PR TITLE
Fix qemu build errors

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -428,6 +428,7 @@ parts:
       - --disable-bsd-user
       - --disable-vhost-user
       - --disable-xen
+      - --disable-werror
       - --prefix=/usr
       - --localstatedir=/var/snap/$CRAFT_PROJECT_NAME/common
       - --sysconfdir=/var/snap/$CRAFT_PROJECT_NAME/common


### PR DESCRIPTION
Qemu build on jammy updates fails with deprecated-declarations warning.
Add flag to disable making warning to errors.

Ubuntu qemu jammy/updates build also disables Werror [1]
[1] https://launchpadlibrarian.net/742807497/buildlog_ubuntu-jammy-amd64.qemu_1%3A6.2+dfsg-2ubuntu6.22_BUILDING.txt.gz