### PR TITLE
Add memory.resident to ceilometer pollsters

### DIFF
--- a/templates/polling.yaml.j2
+++ b/templates/polling.yaml.j2
@@ -8,6 +8,7 @@ sources:
         - cpu
         - cpu_l3_cache
         - memory.usage
+        - memory.resident
         - network.incoming.bytes
         - network.incoming.packets
         - network.outgoing.bytes


### PR DESCRIPTION
Metric memory.resident is required by watcher service.
So add the metric in the list of pollsters to be collected.