### PR TITLE
Fix local tls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,7 @@ fastapi
 netifaces
 pydantic
 
+cryptography==41.0.7
+
 # matched to caracal cloud-archive
 pyroute2==0.7.11

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -25,22 +26,22 @@ sys.modules["libvirt"] = libvirt_mock
 
 
 @pytest.fixture
-def snap_env():
+def snap_env(tmpdir: Path):
     """Environment variables defined in the snap.
 
     This is primarily used to setup the snaphelpers bit.
     """
     yield {
-        "SNAP": "/snap/mysnap/2",
-        "SNAP_COMMON": "/var/snap/mysnap/common",
-        "SNAP_DATA": "/var/snap/mysnap/2",
+        "SNAP": tmpdir / "snap/mysnap/2",
+        "SNAP_COMMON": tmpdir / "var/snap/mysnap/common",
+        "SNAP_DATA": tmpdir / "var/snap/mysnap/2",
         "SNAP_INSTANCE_NAME": "",
         "SNAP_NAME": "mysnap",
         "SNAP_REVISION": "2",
         "SNAP_USER_COMMON": "",
         "SNAP_USER_DATA": "",
         "SNAP_VERSION": "1.2.3",
-        "SNAP_REAL_HOME": "/home/ubuntu",
+        "SNAP_REAL_HOME": tmpdir / "home/ubuntu",
     }
 
 

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -24,7 +24,7 @@ from openstack_hypervisor import hooks
 class TestHooks:
     """Contains tests for openstack_hypervisor.hooks."""
 
-    def test_install_hook(self, snap, os_makedirs):
+    def test_install_hook(self, snap):
         """Tests the install hook."""
         hooks.install(snap)
 
@@ -109,7 +109,7 @@ class TestHooks:
         mock_fs_loader.assert_called_once_with(searchpath=str(snap.paths.snap / "templates"))
 
     def test_configure_hook(
-        self, mocker, snap, os_makedirs, check_call, link_lookup, split, addr, link, ip_interface
+        self, mocker, snap, check_call, link_lookup, split, addr, link, ip_interface
     ):
         """Tests the configure hook."""
         mock_template = mocker.Mock()


### PR DESCRIPTION
Starting libvirt on 24.04 based hosts fails because of missing TLS. This change will initialize a local TLS certificate, which will allow the hypervisor to run in TLS in standalone installations.