### PR TITLE
Add list-nics cli

### DIFF
--- a/openstack_hypervisor/cli/__init__.py
+++ b/openstack_hypervisor/cli/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""openstack_hypervisor - A set of utilities for managing the hypervisor."""

--- a/openstack_hypervisor/cli/interfaces.py
+++ b/openstack_hypervisor/cli/interfaces.py
@@ -1,0 +1,125 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import glob
+import json
+import logging
+import pathlib
+from typing import Iterable
+
+import click
+import pyroute2
+from pyroute2.ndb.objects.interface import Interface
+
+VALUE_FORMAT = "value"
+JSON_FORMAT = "json"
+
+logger = logging.getLogger(__name__)
+
+
+def get_interfaces(ndb) -> list[Interface]:
+    """Get all interfaces from the system."""
+    return list(ndb.interfaces.values())
+
+
+def is_link_local(address: str) -> bool:
+    """Check if address is link local."""
+    return address.startswith("fe80")
+
+
+def is_interface_configured(nic: Interface) -> bool:
+    """Check if interface has an IP address configured."""
+    ipaddr = nic.ipaddr
+    if ipaddr is None:
+        return False
+    for record in ipaddr.summary():
+        if (ip := record["address"]) and not is_link_local(ip):
+            logger.debug("Interface %r has IP address %r", nic["ifname"], ip)
+            return True
+    return False
+
+
+def load_virtual_interfaces() -> list[str]:
+    """Load virtual interfaces from the system."""
+    virtual_nic_dir = "/sys/devices/virtual/net/*"
+    return [pathlib.Path(p).name for p in glob.iglob(virtual_nic_dir)]
+
+
+def filter_candidate_nics(nics: Iterable[Interface]) -> list[str]:
+    """Return a list of candidate nics.
+
+    Candidate nics are:
+      - not part of a bond
+      - not a virtual nic except for bond and vlan
+      - not configured (unless include_configured is True)
+    """
+    configured_nics = []
+    virtual_nics = load_virtual_interfaces()
+    for nic in nics:
+        ifname = nic["ifname"]
+        logger.debug("Checking interface %r", ifname)
+
+        if nic["slave_kind"] == "bond":
+            logger.debug("Ignoring interface %r, it is part of a bond", ifname)
+            continue
+
+        if ifname in virtual_nics:
+            kind = nic["kind"]
+            if kind in ("bond", "vlan"):
+                logger.debug("Interface %r is a %s", ifname, kind)
+            else:
+                logger.debug(
+                    "Ignoring interface %r, it is a virtual interface, kind: %s", ifname, kind
+                )
+                continue
+
+        is_configured = is_interface_configured(nic)
+        logger.debug("Interface %r is configured: %r", ifname, is_configured)
+        if not is_configured:
+            logger.debug("Adding interface %r as a candidate", ifname)
+            configured_nics.append(ifname)
+
+    return configured_nics
+
+
+def display_nics(nics: list[str], candidate_nics: list[str], format: str):
+    """Display the result depending on the format."""
+    if format == VALUE_FORMAT:
+        print("All nics:")
+        for nic in nics:
+            print(nic)
+        if candidate_nics:
+            print("Candidate nics:")
+            for nic in candidate_nics:
+                print(nic)
+    elif format == JSON_FORMAT:
+        print(json.dumps({"nics": nics, "candidates": candidate_nics}, indent=2))
+
+
+@click.command("list-nics")
+@click.option(
+    "-f",
+    "--format",
+    default=JSON_FORMAT,
+    type=click.Choice([VALUE_FORMAT, JSON_FORMAT]),
+    help="Output format",
+)
+def list_nics(format: str):
+    """List nics that are candidates for use by OVN/OVS subsystem.
+
+    This nic will be used by OVS to provide external connectivity to the VMs.
+    """
+    with pyroute2.NDB() as ndb:
+        nics = get_interfaces(ndb)
+        candidate_nics = filter_candidate_nics(nics)
+        display_nics([nic["ifname"] for nic in nics], candidate_nics, format)

--- a/openstack_hypervisor/cli/log.py
+++ b/openstack_hypervisor/cli/log.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import sys
+
+
+def setup_root_logging():
+    """Sets up the root logging level for the application."""
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger()
+    # By default, we'll enable all debug logging.
+    logger.setLevel(logging.DEBUG)
+    verbose = False
+
+    for arg in sys.argv:
+        if arg.lower() in ["-v", "--verbose"]:
+            verbose = True
+            break
+
+    # Reduce pyroute2 logging to warnings only, as it's extra verbose.
+    for namespace in ("pyroute2",):
+        logging.getLogger(namespace).setLevel(logging.WARNING)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.DEBUG if verbose else logging.INFO)
+    logger.addHandler(stream_handler)

--- a/openstack_hypervisor/cli/main.py
+++ b/openstack_hypervisor/cli/main.py
@@ -11,3 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import click
+
+from openstack_hypervisor.cli.interfaces import list_nics
+from openstack_hypervisor.cli.log import setup_root_logging
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+@click.group("init", context_settings=CONTEXT_SETTINGS)
+@click.option("-v", "--verbose", is_flag=True, help="Increase output verbosity")
+def cli(verbose: bool):
+    """Set of utilities for managing the hypervisor."""
+
+
+def main():
+    """Register commands and run the CLI."""
+    setup_root_logging()
+    cli.add_command(list_nics)
+
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ cryptography==41.0.7
 
 # matched to caracal cloud-archive
 pyroute2==0.7.11
+
+click

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ console_scripts =
     ceilometer-compute-agent-service = openstack_hypervisor.services:ceilometer_compute_agent
     ovs-exporter-service = openstack_hypervisor.services:ovs_exporter
     masakari-instancemonitor-service = openstack_hypervisor.services:masakari_instancemonitor
+    hypervisor = openstack_hypervisor.cli.main:main
 
 snaphelpers.hooks =
     configure = openstack_hypervisor.hooks:configure

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,6 +69,12 @@ package-repositories:
     url: http://ubuntu-cloud.archive.canonical.com/ubuntu
 
 apps:
+  openstack-hypervisor:
+    command: bin/hypervisor
+    plugs:
+      - network
+      - network-observe
+
   # Libvirt
   libvirtd:
     environment:

--- a/tests/unit/cli/test_interfaces.py
+++ b/tests/unit/cli/test_interfaces.py
@@ -1,0 +1,78 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openstack_hypervisor.cli.interfaces import filter_candidate_nics
+
+INTERFACES = [
+    {
+        "ifname": "eth0",
+        "slave_kind": None,
+        "kind": "eth",
+        "ipaddr": [{"address": "192.168.1.1"}],
+    },
+    {
+        "ifname": "eth1",
+        "slave_kind": "bond",
+        "kind": "eth",
+        "ipaddr": [{"address": "192.168.1.2"}],
+    },
+    {
+        "ifname": "eth2",
+        "slave_kind": None,
+        "kind": "eth",
+        "ipaddr": [],
+    },
+    {
+        "ifname": "vlan0",
+        "slave_kind": None,
+        "kind": "vlan",
+        "ipaddr": [{"address": "fe80::1"}],  # link local
+    },
+    {
+        "ifname": "bond0",
+        "slave_kind": None,
+        "kind": "bond",
+        "ipaddr": [{"address": "192.168.1.3"}],
+    },
+    {
+        "ifname": "bond1",
+        "slave_kind": None,
+        "kind": "bond",
+        "ipaddr": [],
+    },
+]
+
+
+@pytest.fixture
+def mock_interfaces():
+    nics = []
+    for interface in INTERFACES:
+        iface = MagicMock()
+        iface.__getitem__.side_effect = interface.__getitem__
+        iface.ipaddr.summary.return_value = interface["ipaddr"]
+        nics.append(iface)
+
+    return nics
+
+
+@patch(
+    "openstack_hypervisor.cli.interfaces.load_virtual_interfaces",
+    return_value=["vlan0", "bond0", "bond1"],
+)
+def test_filter_candidate_nics(mock_load_virtual_interfaces, mock_interfaces):
+    result = filter_candidate_nics(mock_interfaces)
+    assert result == ["eth2", "vlan0", "bond1"]


### PR DESCRIPTION
Add cli capabilities under the snap top-level name. Add a `list-nic` command to allow the snap returning the nics present, and which are candidates for being pulled in OVN/OVS.

Example:
```
root@microstack:~# openstack-hypervisor -v list-nics
DEBUG:openstack_hypervisor.cli.interfaces:Checking interface 'lo'
Checking interface 'lo'
DEBUG:openstack_hypervisor.cli.interfaces:Ignoring interface 'lo', it is a virtual interface, kind: None
Ignoring interface 'lo', it is a virtual interface, kind: None
DEBUG:openstack_hypervisor.cli.interfaces:Checking interface 'enp5s0'
Checking interface 'enp5s0'
DEBUG:openstack_hypervisor.cli.interfaces:Interface 'enp5s0' has IP address '10.206.54.100'
Interface 'enp5s0' has IP address '10.206.54.100'
DEBUG:openstack_hypervisor.cli.interfaces:Interface 'enp5s0' is configured: True
Interface 'enp5s0' is configured: True
DEBUG:openstack_hypervisor.cli.interfaces:Checking interface 'enp6s0'
Checking interface 'enp6s0'
DEBUG:openstack_hypervisor.cli.interfaces:Ignoring interface 'enp6s0', it is part of a bond
Ignoring interface 'enp6s0', it is part of a bond
DEBUG:openstack_hypervisor.cli.interfaces:Checking interface 'enp7s0'
Checking interface 'enp7s0'
DEBUG:openstack_hypervisor.cli.interfaces:Ignoring interface 'enp7s0', it is part of a bond
Ignoring interface 'enp7s0', it is part of a bond
DEBUG:openstack_hypervisor.cli.interfaces:Checking interface 'bond0'
Checking interface 'bond0'
DEBUG:openstack_hypervisor.cli.interfaces:Interface 'bond0' is a bond
Interface 'bond0' is a bond
DEBUG:openstack_hypervisor.cli.interfaces:Interface 'bond0' has IP address 'fd42:8c2:957a:d1e:4c2c:c7ff:febf:9f4d'
Interface 'bond0' has IP address 'fd42:8c2:957a:d1e:4c2c:c7ff:febf:9f4d'
DEBUG:openstack_hypervisor.cli.interfaces:Interface 'bond0' is configured: True
Interface 'bond0' is configured: True
DEBUG:openstack_hypervisor.cli.interfaces:Checking interface 'bond0.100'
Checking interface 'bond0.100'
DEBUG:openstack_hypervisor.cli.interfaces:Interface 'bond0.100' is a vlan
Interface 'bond0.100' is a vlan
DEBUG:openstack_hypervisor.cli.interfaces:Interface 'bond0.100' is configured: False
Interface 'bond0.100' is configured: False
DEBUG:openstack_hypervisor.cli.interfaces:Adding interface 'bond0.100' as a candidate
Adding interface 'bond0.100' as a candidate
DEBUG:openstack_hypervisor.cli.interfaces:Checking interface 'ovs-system'
Checking interface 'ovs-system'
DEBUG:openstack_hypervisor.cli.interfaces:Ignoring interface 'ovs-system', it is a virtual interface, kind: openvswitch
Ignoring interface 'ovs-system', it is a virtual interface, kind: openvswitch
DEBUG:openstack_hypervisor.cli.interfaces:Checking interface 'br-int'
Checking interface 'br-int'
DEBUG:openstack_hypervisor.cli.interfaces:Ignoring interface 'br-int', it is a virtual interface, kind: openvswitch
Ignoring interface 'br-int', it is a virtual interface, kind: openvswitch
{
  "nics": [
    "lo",
    "enp5s0",
    "enp6s0",
    "enp7s0",
    "bond0",
    "bond0.100",
    "ovs-system",
    "br-int"
  ],
  "candidates": [
    "bond0.100"
  ]
}
```

Cli help:
```
root@microstack:~# openstack-hypervisor -h
Usage: hypervisor [OPTIONS] COMMAND [ARGS]...

  Set of utilities for managing the hypervisor.

Options:
  -v, --verbose  Increase output verbosity
  -h, --help     Show this message and exit.

Commands:
  list-nics  List nics that are candidates for use by OVN/OVS subsystem.
```

```
openstack-hypervisor list-nics -h
Usage: hypervisor list-nics [OPTIONS]

  List nics that are candidates for use by OVN/OVS subsystem.

  This nic will be used by OVS to provide external connectivity to the VMs.

Options:
  -f, --format [value|json]  Output format
  -h, --help                 Show this message and exit.
```
