### PR TITLE
Add configured interfaces as candidate

### DIFF
--- a/openstack_hypervisor/cli/interfaces.py
+++ b/openstack_hypervisor/cli/interfaces.py
@@ -115,9 +115,8 @@ def filter_candidate_nics(nics: Iterable[Interface]) -> list[str]:
 
         is_configured = is_interface_configured(nic)
         logger.debug("Interface %r is configured: %r", ifname, is_configured)
-        if not is_configured:
-            logger.debug("Adding interface %r as a candidate", ifname)
-            configured_nics.append(ifname)
+        logger.debug("Adding interface %r as a candidate", ifname)
+        configured_nics.append(ifname)
 
     return configured_nics
 
@@ -143,8 +142,7 @@ def display_nics(nics: NicList, candidate_nics: list[str], format: str):
         print("All nics:")
         for nic in nics.root:
             print(
-                nic.name,
-                ",",
+                nic.name + ",",
                 "configured:",
                 nic.configured,
                 "up:",

--- a/tests/unit/cli/test_interfaces.py
+++ b/tests/unit/cli/test_interfaces.py
@@ -75,4 +75,4 @@ def mock_interfaces():
 )
 def test_filter_candidate_nics(mock_load_virtual_interfaces, mock_interfaces):
     result = filter_candidate_nics(mock_interfaces)
-    assert result == ["eth2", "vlan0", "bond1"]
+    assert result == ["eth0", "eth2", "vlan0", "bond0", "bond1"]


### PR DESCRIPTION
The openstack snap will prompt (in interactive mode) for confirmation when adding a configured nic candidate.

This commands returns in the structured format if a NIC is configured or not.

Tidy a bit format value output.