### PR TITLE
Add support for detection of AMD SEV

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ IP address to use for configuration of SPICE consoles in instances.
 
 Whether to resume instances on boot or not.
 
+* `compute.flavors` Flavor of the compute host
+
+Comma separated string of Flavors like SEV, SRIOV, DPDK.
+Currently SEV is supported for instance memory encryption.
+
+Valid values: `sev`
+
+* `sev.reserved-host-memory-mb` Host memory reserved
+
+Amount of memory reserved for host in MB. nova-compute service deducts this
+memory from the available memory in the usage report sent to the placement
+service.
+
 ### identity
 
 Configuration of options related to identity (Keystone):

--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -30,6 +30,14 @@ resume_guests_state_on_host_boot = {{ compute.resume_on_boot }}
 # To collect compute node related metrics
 compute_monitors = cpu.virt_driver
 
+{% if 'sev' in compute.flavors -%}
+# Set ram_allocation_ratio to 1.0 as SEV is enabled
+ram_allocation_ratio = 1.0
+{% if sev and sev.reserved_host_memory_mb -%}
+reserved_host_memory_mb  = {{ sev.reserved_host_memory_mb }}
+{% endif %}
+{% endif %}
+
 [workarounds]
 disable_rootwrap = True
 
@@ -48,6 +56,11 @@ live_migration_inbound_addr = {{ compute.migration_address }}
 {% if compute.rbd_secret_uuid -%}
 rbd_user = {{ compute.rbd_user }}
 rbd_secret_uuid = {{ compute.rbd_secret_uuid }}
+{% endif %}
+
+{% if 'sev' in compute.flavors -%}
+# hw_machine_type set to q35 as sev is enabled
+hw_machine_type = x86_64=q35
 {% endif %}
 
 [oslo_concurrency]


### PR DESCRIPTION
* Add new config compute.flavors This is a placeholder to add compute flavors.
The value will be a list of comma separated flavors. Flavor name for AMD SEV is sev.
* Add new config sev.reserved-host-memory-mb to reserve memory for host
* Detect if AMD SEV is enabled at kernel param file and libvirtd domain capabilities
* Update compute.flavors with sev if AMD SEV is detected
* Update nova compute configurations if AMD SEV is enabled