### PR TITLE
Add read access to SEV kernel param file

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -699,6 +699,7 @@ hooks:
       - network-control
       - firewall-control
       - microstack-support
+      - kvm
   connect-slot-hypervisor-config:
     plugs:
       - network


### PR DESCRIPTION
Configure hook tries to read the SEV kernel
param file to detect if SEV is enabled or not.
kvm plug provide read access to the SEV kernel
param file. So add kvm as plug to configure
hook.