### PR TITLE
Change requirement of snapd version to 2.68

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
   The OpenStack Hypervisor snap provides the requires components
   to operate a cloud hypervisor as part of an OpenStack deployment.
 assumes:
-- snapd2.61
+- snapd2.68
 grade: stable
 confinement: strict
 environment:


### PR DESCRIPTION
Detection of AMD SEV requires snapd change [1]
The change will be part of snapd 2.68

Change assumes to snapd2.68

[1] https://github.com/canonical/snapd/pull/15033