### PR TITLE
Include rust tools as build packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -667,6 +667,8 @@ parts:
     source: .
     build-packages:
       - git
+      - cargo
+      - rustc
     python-requirements:
       - requirements.txt
     after:


### PR DESCRIPTION
Multiple dependencies depend on rust tools to be available to build, such as pydantic.

In amd64 / arm64, pip manages to get the toolchain (or it's in the default snapcraft image), but that's not the case for s390x, include as build-packages.