### PR TITLE
Move pytest to test-requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,4 @@
 pyroute2
+
+pytest
+pytest-mock

--- a/tox.ini
+++ b/tox.ini
@@ -48,8 +48,6 @@ commands =
 [testenv:unit]
 description = Run unit tests
 deps =
-    pytest
-    pytest-mock
     coverage[toml]
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
TICS scan requires installation of all
dependency packages. pytest is installed
from tox in tox tests, however TICS workflow
uses *requirements.txt to install dependencies.

Move pytest to test-requirements.txt