### PR TITLE
Add setuptools-scm to build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@
 [build-system]
 requires = [
     "setuptools",
+    "setuptools-scm",
     "pbr>=2.0.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Add setuptools-scm to build system. Wihtout
this change the subfolders are not copied
during the package build.