### PR TITLE
Define pci-passthrough-whitelist setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ Amount of memory reserved for host in MB. nova-compute service deducts this
 memory from the available memory in the usage report sent to the placement
 service.
 
+* `compute.pci-passthrough-whitelist` PCI passthrough whitelist
+
+Sets the pci_passthrough_whitelist option in nova.conf which allows PCI
+passthrough of specific devices to VMs.
+
+Example applications: GPU processing, SR-IOV networking, etc.
+
+NOTE: For PCI passthrough to work IOMMU must be enabled on the machine
+deployed to. This can be accomplished by setting kernel parameters on
+capable machines in MAAS, tagging them and using these tags as
+constraints in the model.
+
+
 ### identity
 
 Configuration of options related to identity (Keystone):

--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -260,6 +260,7 @@ DEFAULT_CONFIG = {
     "compute.migration-address": UNSET,
     "compute.resume-on-boot": True,
     "compute.flavors": UNSET,
+    "compute.pci-passthrough-whitelist": UNSET,
     "sev.reserved-host-memory-mb": UNSET,
     # Neutron
     "network.physnet-name": "physnet1",

--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -63,6 +63,11 @@ rbd_secret_uuid = {{ compute.rbd_secret_uuid }}
 hw_machine_type = x86_64=q35
 {% endif %}
 
+[pci]
+{% if compute.pci_passthrough_whitelist -%}
+pci_passthrough_whitelist = {{ compute.pci_passthrough_whitelist }}
+{% endif -%}
+
 [oslo_concurrency]
 # Oslo Concurrency lock path
 lock_path = {{ snap_common }}/lock


### PR DESCRIPTION
We'll allow setting the `pci.pci_passthrough_whitelist` n-cpu option, which can be used to expose PCI devices such as GPU devices or SR-IOV VFs.

The patch preserves the naming and description from the old reactive charm: https://opendev.org/openstack/charm-nova-compute/src/commit/25a0aba59d0b760b1c12b2c99c269aad80d2e087/config.yaml#L224-L236