### PR TITLE
Allow excluding PCI devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,27 @@ deployed to. This can be accomplished by setting kernel parameters on
 capable machines in MAAS, tagging them and using these tags as
 constraints in the model.
 
+* `compute.pci-excluded-devices` PCI excluded devices
+
+A list of PCI addresses that will be excluded from the Nova PCI device whitelist.
+The main purpose of this setting is to accommodate per-node exclusion lists.
+
+For example, let's say that the user whitelisted all Intel x550 devices and then
+excluded one out of 4 such interfaces:
+    pci_device_specs = [{"vendor_id": "8086", "product_id": "1563"}]
+    excluded_devices = ["0000:1b:00.1"]
+
+The updated device spec will contain the vendor/product and pci address of the remaining
+3 Intel x550 devies.
+
+    [
+        {"vendor_id": "8086", "product_id": "1563", "address": "0000:19:00.0"},
+        {"vendor_id": "8086", "product_id": "1563", "address": "0000:19:00.1"},
+        {"vendor_id": "8086", "product_id": "1563", "address": "0000:1b:00.0"},
+    ]
+
+A device spec that doesn't contain any excluded devices will not be modified.
+
 * `compute.pci-aliases` PCI device alias
 
 Sets the `pci-alias` option in nova.conf, defining aliases for assignable

--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -33,6 +33,7 @@ from pyroute2.netlink.exceptions import NetlinkError
 from snaphelpers import Snap
 from snaphelpers._conf import UnknownConfigKey
 
+from openstack_hypervisor import pci
 from openstack_hypervisor.cli import interfaces
 from openstack_hypervisor.log import setup_logging
 
@@ -262,6 +263,7 @@ DEFAULT_CONFIG = {
     "compute.resume-on-boot": True,
     "compute.flavors": UNSET,
     "compute.pci-device-specs": [],
+    "compute.pci-excluded-devices": [],
     "compute.pci-aliases": [],
     "sev.reserved-host-memory-mb": UNSET,
     # Neutron
@@ -1679,6 +1681,14 @@ def configure(snap: Snap) -> None:
     )
 
     pci_device_specs = context.get("compute", {}).get("pci_device_specs")
+    pci_excluded_devices = context.get("compute", {}).get("pci_excluded_devices")
+    if isinstance(pci_device_specs, str):
+        pci_device_specs = json.loads(pci_device_specs) or []
+    if isinstance(pci_excluded_devices, str):
+        pci_excluded_devices = json.loads(pci_excluded_devices) or []
+
+    pci_device_specs = pci.apply_exclusion_list(pci_device_specs, pci_excluded_devices)
+
     _set_config_context(context, "compute", "pci_device_specs", _to_json_list(pci_device_specs))
 
     pci_aliases = context.get("compute", {}).get("pci_aliases")

--- a/openstack_hypervisor/pci.py
+++ b/openstack_hypervisor/pci.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2025 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import logging
+import os
+import subprocess
+
+from openstack_hypervisor import devspec
+
+LOG = logging.getLogger(__name__)
+
+
+def get_pci_product_id(address: str) -> str:
+    """Determine the PCI product id for the specified PCI address."""
+    path = f"/sys/bus/pci/devices/{address}/device"
+    if not os.path.exists(path):
+        return ""
+    with open(path, "r") as f:
+        return f.read().strip()
+
+
+def get_pci_vendor_id(address: str) -> str:
+    """Determine the PCI vendor id for the specified PCI address."""
+    path = f"/sys/bus/pci/devices/{address}/vendor"
+    if not os.path.exists(path):
+        return ""
+    with open(path, "r") as f:
+        return f.read().strip()
+
+
+def get_pci_description(address: str) -> dict:
+    """Obtain human readable PCI information.
+
+    Leverages "lspci -vmm" to obtain human readable PCI
+    vendor and product names as opposed to parsing
+    /usr/share/misc/pci.ids directly.
+    """
+    result = subprocess.run(
+        ["lspci", "-s", address, "-vmm"], capture_output=True, check=True, text=True
+    )
+    lines = result.stdout.replace("\t", "").split("\n")
+    raw_dict = {}
+    for line in lines:
+        if ":" not in line:
+            continue
+        key, val = line.split(":", 1)
+        raw_dict[key] = val
+
+    return {
+        "class_name": raw_dict.get("Class"),
+        "vendor_name": raw_dict.get("Vendor"),
+        "device_name": raw_dict.get("Device"),
+        "subsystem_vendor_name": raw_dict.get("SVendor"),
+        "subsystem_device_name": raw_dict.get("SDevice"),
+    }
+
+
+def get_physfn_address(address: str) -> str:
+    """Get the corresponding PF PCI address for a given VF."""
+    path = f"/sys/bus/pci/devices/{address}/physfn"
+    if not (os.path.exists(path) and os.path.islink(path)):
+        # Not a VF.
+        return ""
+    resolved_path = os.path.realpath(path)
+    return resolved_path.split("/")[-1]
+
+
+def list_pci_devices() -> list[dict]:
+    """Enumerate PCI devices."""
+    devices = []
+    addresses = os.listdir("/sys/bus/pci/devices/")
+    for address in addresses:
+        device = {
+            "address": address,
+            "product_id": get_pci_product_id(address),
+            "vendor_id": get_pci_vendor_id(address),
+            "physfn_address": get_physfn_address(address),
+        }
+        devices.append(device)
+    return devices
+
+
+def apply_exclusion_list(pci_device_specs: list[dict], excluded_devices: list[str]) -> list[dict]:
+    """Exclude the specified devices from Nova's pci device whitelist.
+
+    Receives a pci device spec list as defined by Nova[1] and a list of excluded
+    PCI addresses. Updates the pci device specs based on the exclusion list and
+    the identified PCI devices.
+
+    For example, let's say that the user whitelisted all Intel x550 devices and then
+    excluded one out of 4 such interfaces:
+        pci_device_specs = [{"vendor_id": "8086", "product_id": "1563"}]
+        excluded_devices = ["0000:1b:00.1"]
+
+    The updated device spec will contain the vendor/product and pci address of the remaining
+    3 Intel x550 devies.
+
+        [
+            {"vendor_id": "8086", "product_id": "1563", "address": "0000:19:00.0"},
+            {"vendor_id": "8086", "product_id": "1563", "address": "0000:19:00.1"},
+            {"vendor_id": "8086", "product_id": "1563", "address": "0000:1b:00.0"},
+        ]
+
+    A device spec that doesn't contain any excluded devices will not be modified.
+
+    [1] https://docs.openstack.org/nova/latest/configuration/config.html#pci.device_spec
+    """
+    LOG.debug(
+        "Applying PCI exclusion list. PCI device specs: %s, excluded devices: %s",
+        pci_device_specs,
+        excluded_devices,
+    )
+    if not excluded_devices:
+        LOG.debug("No excluded devices, no changes made.")
+        return pci_device_specs
+
+    all_pci_devices = list_pci_devices()
+
+    updated_pci_device_specs: list[dict] = []
+    for dev_spec in pci_device_specs:
+        if not isinstance(dev_spec, dict):
+            raise ValueError("Invalid device spec, expecting a dict: %s." % dev_spec)
+        pci_spec = devspec.PciDeviceSpec(dev_spec)
+
+        # Converted device spec obtained by replacing wildcards and product/vendor id
+        # rules with exact PCI addresses.
+        granular_device_specs = []
+        # Specifies if there are PCI devices matched by this device spec which are also
+        # in the exclusion list, in which case the device spec must be replaced with
+        # a granular whitelist.
+        matched_excluded_devices = False
+        for device in all_pci_devices:
+            match = pci_spec.match(
+                {
+                    "vendor_id": device["vendor_id"].lstrip("0x"),
+                    "product_id": device["product_id"].lstrip("0x"),
+                    "address": device["address"],
+                    "parent_addr": device["physfn_address"],
+                }
+            )
+            if match:
+                if device["address"] in excluded_devices:
+                    matched_excluded_devices = True
+                    # Device excluded, do not include it in our granular
+                    # device spec.
+                else:
+                    granular_spec = copy.deepcopy(dev_spec)
+                    # Apply granular PCI filters.
+                    granular_spec.update(
+                        {
+                            "vendor_id": device["vendor_id"],
+                            "product_id": device["product_id"],
+                            "address": device["address"],
+                        }
+                    )
+                    granular_device_specs.append(granular_spec)
+
+        if matched_excluded_devices:
+            updated_pci_device_specs += granular_device_specs
+        else:
+            updated_pci_device_specs.append(dev_spec)
+
+    LOG.debug("New PCI whitelist: %s", updated_pci_device_specs)
+    return updated_pci_device_specs

--- a/tests/unit/test_pci.py
+++ b/tests/unit/test_pci.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2022 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import mock
+
+import pytest
+
+from openstack_hypervisor import pci
+
+
+class TestPCIUtils:
+    """Contains tests for the PCI utils."""
+
+    @pytest.mark.parametrize(
+        "device_specs, excluded_devices, pci_device_list, expected_result",
+        [
+            # Multiple PFs match the device spec, one of them is in the exclusion list.
+            (
+                [
+                    # Matches excluded devices, will be converted to a granular set of
+                    # device specs.
+                    {
+                        "vendor_id": "8086",
+                        "product_id": "1563",
+                        "physical_network": "physnet1",
+                    },
+                    # Does not match excluded devices, will be passed as-is.
+                    {
+                        "vendor_id": "15b3",
+                        "product_id": "1007",
+                        "physical_network": "physnet2",
+                    },
+                ],
+                ["0000:1b:00.1"],
+                [
+                    {
+                        "vendor_id": "8086",
+                        "product_id": "1563",
+                        "address": "0000:19:00.0",
+                        "physfn_address": "",
+                    },
+                    {
+                        "vendor_id": "8086",
+                        "product_id": "1563",
+                        "address": "0000:19:00.1",
+                        "physfn_address": "",
+                    },
+                    {
+                        "vendor_id": "8086",
+                        "product_id": "1563",
+                        "address": "0000:1b:00.0",
+                        "physfn_address": "",
+                    },
+                    {
+                        "vendor_id": "8086",
+                        "product_id": "1563",
+                        "address": "0000:1b:00.1",
+                        "physfn_address": "",
+                    },
+                    {
+                        "vendor_id": "15b3",
+                        "product_id": "1007",
+                        "address": "0000:5e:00.0",
+                        "physfn_address": "",
+                    },
+                ],
+                [
+                    {
+                        "vendor_id": "8086",
+                        "product_id": "1563",
+                        "address": "0000:19:00.0",
+                        "physical_network": "physnet1",
+                    },
+                    {
+                        "vendor_id": "8086",
+                        "product_id": "1563",
+                        "address": "0000:19:00.1",
+                        "physical_network": "physnet1",
+                    },
+                    {
+                        "vendor_id": "8086",
+                        "product_id": "1563",
+                        "address": "0000:1b:00.0",
+                        "physical_network": "physnet1",
+                    },
+                    {
+                        "vendor_id": "15b3",
+                        "product_id": "1007",
+                        "physical_network": "physnet2",
+                    },
+                ],
+            ),
+        ],
+    )
+    def test_apply_exclusion_list(
+        self,
+        device_specs: list[dict],
+        excluded_devices: list[str],
+        pci_device_list: list[dict],
+        expected_result,
+    ):
+        with mock.patch.object(pci, "list_pci_devices") as mock_list_devices:
+            mock_list_devices.return_value = pci_device_list
+            result = pci.apply_exclusion_list(device_specs, excluded_devices)
+
+        assert expected_result == result


### PR DESCRIPTION
Sunbeam will allow setting global PCI whitelists and per-node exclusion lists.

This patch applies the configured exclusion lists, converting the whitelist to more granular PCI filters, leaving out excluded devices.

For example, let's say that the user whitelisted all Intel x550 devices and then excluded one out of 4 such interfaces:

```
    pci_device_specs = [{"vendor_id": "8086", "product_id": "1563"}]
    excluded_devices = ["0000:1b:00.1"]
```

The updated device spec will contain the vendor/product and pci address of the remaining 3 Intel x550 devies.

```
    [
        {"vendor_id": "8086", "product_id": "1563", "address": "0000:19:00.0"},
        {"vendor_id": "8086", "product_id": "1563", "address": "0000:19:00.1"},
        {"vendor_id": "8086", "product_id": "1563", "address": "0000:1b:00.0"},
    ]
```

Note that the implementation is not tied to SR-IOV and can work with any PCI device.

`snap set` example:

```
$ sudo snap set openstack-hypervisor compute.pci-device-specs='[{"vendor_id": "8086", "product_id": "1563", "physical_network": "physnet1"}]'

$ sudo cat /var/snap/openstack-hypervisor/common/etc/neutron/neutron_sriov_nic_agent.ini  | grep mappings
physical_device_mappings = physnet1:eno4,physnet1:eno1,physnet1:eno2,physnet1:eno3

$ sudo cat /var/snap/openstack-hypervisor/common/etc/nova/nova.conf | grep device_spec
device_spec = {"physical_network": "physnet1", "product_id": "1563", "vendor_id": "8086"}

# Exclude one of the devices and check the updated configuration.
$ sudo snap set openstack-hypervisor compute.pci-excluded-devices='["0000:1b:00.1"]'

$ sudo cat /var/snap/openstack-hypervisor/common/etc/nova/nova.conf | grep device_spec
device_spec = {"physical_network": "physnet1", "product_id": "0x1563", "vendor_id": "0x8086", "address": "0000:19:00.0"}
device_spec = {"physical_network": "physnet1", "product_id": "0x1563", "vendor_id": "0x8086", "address": "0000:1b:00.0"}
device_spec = {"physical_network": "physnet1", "product_id": "0x1563", "vendor_id": "0x8086", "address": "0000:19:00.1"}

$ sudo cat /var/snap/openstack-hypervisor/common/etc/neutron/neutron_sriov_nic_agent.ini  | grep mappings
physical_device_mappings = physnet1:eno2,physnet1:eno3,physnet1:eno1
```