### PR TITLE
Disable `report_in_placement` to allow SR-IOV Neutron ports

### DIFF
--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -64,7 +64,10 @@ hw_machine_type = x86_64=q35
 {% endif %}
 
 [pci]
-report_in_placement = True
+# TODO: consider enabling the following once Nova supports
+# tracking SR-IOV ports consumed by Neutron.
+# https://docs.openstack.org/nova/latest/admin/pci-passthrough.html
+# report_in_placement = True
 {% for spec in compute.pci_device_specs -%}
   device_spec = {{ spec }}
 {% endfor -%}


### PR DESCRIPTION
Nova doesn't yet support tracking SR-IOV ports consumed by Neutron using the Placement service [1].

```
In nova 26.0.0 (Zed) the Placement resource tracking of PCI devices
does not support SR-IOV devices intended to be consumed via Neutron
ports and therefore having physical_network tag in pci.device_spec.
Such devices are supported via the legacy PCI tracker code path in Nova.

In Antelope flavor based PCI requests are supported but Neutron
port base PCI requests are not handled in Placement.
```

If `report_in_placement` is enabled, attempting to attach Neutron ports will fail.

```
Failed to allocate PCI devices for instance. Unassigning devices
back to pools. This should not happen, since the scheduler should
have accurate information, and allocation during claims is controlled
via a hold on the compute node semaphore.
```

Furthermore, once enabled this setting cannot be disabled.

```
Please note that once it is enabled on a given compute host it cannot
be disabled there any more.
```

That being considered, we'll disable `report_in_placement` for now.

[1] https://docs.openstack.org/nova/latest/admin/pci-passthrough.html