### PR TITLE
Revert "libvirt: add "kernel-module-control" plug"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,7 +96,6 @@ apps:
       - hardware-observe
       - hugepages-control
       - kvm
-      - kernel-module-control
       - kernel-module-observe
       - process-control
       - mount-observe


### PR DESCRIPTION
We're still investigating hw offload permission errors so we'll drop this plug for now.

This reverts commit 5e8766b922720f4440cf49110683095055be1d06.

Even with `kernel-module-control`, we still get the following libvirt error:

```
ERROR: could not insert 'mlx5_vfio_pci': Operation not permitted
```

There's no apparmor deny in the logs, however it seems to get a bit further if I install the snap with --devmode.
I then get a different error, but at least it gets to the point in which libvirt tells qemu to attach the VF.

```
internal error: unable to execute QEMU command 'device_add':
vfio 0000:04:00.5: error getting device from group 103:
Permission denied
```