### PR TITLE
Bump snapd requirement

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
   The OpenStack Hypervisor snap provides the requires components
   to operate a cloud hypervisor as part of an OpenStack deployment.
 assumes:
-- snapd2.68
+- snapd2.71
 grade: stable
 confinement: strict
 environment:


### PR DESCRIPTION
The following snapd patch updated the "microstack_support" interface in order to accommodate the sr-iov feature:

https://github.com/canonical/snapd/commit/37aadb80a84ace3e376806b199de9fdbeba43cbd

It has been included in 2.71, we'll need to bump the snapd dependency *as soon as it reaches the stable channel*.

In the meantime, we've documented the fact that the sr-iov feature requires snapd >= 2.71.

https://github.com/canonical/canonical-openstack-docs/pull/92

The "microstack_support" interface defined in snapd was updated