### PR TITLE
Ensure snap data is not access out of band

### DIFF
--- a/openstack_hypervisor/cli/interfaces.py
+++ b/openstack_hypervisor/cli/interfaces.py
@@ -200,9 +200,8 @@ def filter_candidate_nics(nics: Iterable[Interface]) -> list[str]:
     return configured_nics
 
 
-def _get_pci_spec_cfg():
-    snap = Snap()
-
+def _get_pci_spec_cfg(snap: Snap):
+    """Get the PCI spec configuration from the snap config."""
     try:
         pci_spec_cfg = snap.config.get("compute.pci-device-specs") or []
         if isinstance(pci_spec_cfg, str):
@@ -280,11 +279,11 @@ def _get_nic_pci_info(pci_address: str, pci_spec_cfg: list[dict]) -> dict:
     return out
 
 
-def to_output_schema(nics: list[Interface]) -> NicList:  # noqa: C901
+def to_output_schema(snap: Snap, nics: list[Interface]) -> NicList:  # noqa: C901
     """Convert the interfaces to the output schema."""
     nics_ = []
 
-    pci_spec_cfg = _get_pci_spec_cfg()
+    pci_spec_cfg = _get_pci_spec_cfg(snap)
     processed_pci_addresses = []
 
     for nic in nics:
@@ -364,7 +363,8 @@ def display_nics(nics: NicList, candidate_nics: list[str], format: str):
     type=click.Choice([VALUE_FORMAT, TABLE_FORMAT, JSON_FORMAT, JSON_INDENT_FORMAT]),
     help="Output format",
 )
-def list_nics(format: str):
+@click.pass_obj
+def list_nics(snap: Snap, format: str):
     """List nics that are candidates for use by OVN/OVS subsystem.
 
     This nic will be used by OVS to provide external connectivity to the VMs.
@@ -379,13 +379,13 @@ def list_nics(format: str):
     with pyroute2.NDB() as ndb:
         nics = get_interfaces(ndb)
         candidate_nics = filter_candidate_nics(nics)
-        nics_ = to_output_schema(nics)
+        nics_ = to_output_schema(snap, nics)
     display_nics(nics_, candidate_nics, format)
 
 
-def get_nics() -> NicList:
+def get_nics(snap: Snap) -> NicList:
     """List nics that are candidates for use by OVN/OVS subsystem."""
     # TODO: consider moving out reusable functions.
     with pyroute2.NDB() as ndb:
         nics = get_interfaces(ndb)
-        return to_output_schema(nics)
+        return to_output_schema(snap, nics)

--- a/openstack_hypervisor/cli/main.py
+++ b/openstack_hypervisor/cli/main.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import click
+from snaphelpers import Snap
 
 from openstack_hypervisor.cli.hypervisor import hypervisor
 from openstack_hypervisor.cli.interfaces import list_nics
@@ -16,14 +17,14 @@ def cli(verbose: bool):
     """Set of utilities for managing the hypervisor."""
 
 
-def main():
+def main(snap: Snap):
     """Register commands and run the CLI."""
     setup_root_logging()
     cli.add_command(list_nics)
     cli.add_command(hypervisor)
 
-    cli()
+    cli(obj=snap)
 
 
 if __name__ == "__main__":
-    main()
+    main(Snap())

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -541,7 +541,7 @@ class TestHooks:
         )
 
     @mock.patch.object(interfaces, "get_nics")
-    def test_set_sriov_context(self, mock_get_nics):
+    def test_set_sriov_context(self, mock_get_nics, snap):
         sriov_pf_specs = dict(
             sriov_available=True,
             sriov_numvfs=32,
@@ -613,7 +613,7 @@ class TestHooks:
         mock_get_nics.return_value = mock.Mock(root=nic_list)
 
         context = {}
-        hooks._set_sriov_context(context)
+        hooks._set_sriov_context(snap, context)
         expected_bridge_mappings = "physnet1:eno4,physnet2:eno5"
 
         assert sorted(expected_bridge_mappings.split(",")) == sorted(
@@ -648,6 +648,8 @@ def test_nova_conf_cpu_pinning_injection(
         "_configure_ceph",
         "_configure_masakari_services",
         "_configure_sriov_agent_service",
+        "_set_sriov_context",
+        "_set_pci_context",
     ]:
         mocker.patch(f"openstack_hypervisor.hooks.{fn}")
 


### PR DESCRIPTION
Snap values should not be access at import time, and should not be instantiated directly in helper method, ensure control propagation of the snap object.