### PR TITLE
Only configure sriov physical devices if value

### DIFF
--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -1672,7 +1672,8 @@ def _set_sriov_context(snap: Snap, context: dict):  # noqa: C901
 
     if "network" not in context:
         context["network"] = {}
-    context["network"]["sriov_nic_physical_device_mappings"] = mappings_str
+    if mappings_str:
+        context["network"]["sriov_nic_physical_device_mappings"] = mappings_str
     context["network"]["hw_offloading"] = hw_offloading
 
 

--- a/templates/neutron_sriov_nic_agent.ini.j2
+++ b/templates/neutron_sriov_nic_agent.ini.j2
@@ -5,5 +5,7 @@ host = {{ node.fqdn }}
 firewall_driver = noop
 
 [sriov_nic]
+{%- if network.sriov_nic_physical_device_mappings is defined %}
 physical_device_mappings = {{ network.sriov_nic_physical_device_mappings }}
+{% endif -%}
 exclude_devices = {{ network.sriov_nic_exclude_devices }}


### PR DESCRIPTION
Network context is not meant to hold unset values, multiple services rely on this whole context to be configured before starting.