### PR TITLE
Enable pci.report_in_placement

### DIFF
--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -77,10 +77,8 @@ hw_machine_type = x86_64=q35
 {% endif %}
 
 [pci]
-# TODO: consider enabling the following once Nova supports
-# tracking SR-IOV ports consumed by Neutron.
 # https://docs.openstack.org/nova/latest/admin/pci-passthrough.html
-# report_in_placement = True
+report_in_placement = True
 {% for spec in compute.pci_device_specs -%}
   device_spec = {{ spec }}
 {% endfor -%}


### PR DESCRIPTION
We previously had some issues with SR-IOV devices and placement reporting. Nova docs also made it seem like this scenario is unsupported.

Those issues were addressed by explicitly whitelisting VFs instead of PFs

Sample: https://paste.ubuntu.com/p/vTg3GZVKz6/plain/

VFs that have an associated physnet will not be reported to the placement service, however they can still be attached, leveraging the old Nova PCI tracker.

(cherry picked from commit 9ab895ae223f3a9ddb91eeb1b4353087ce97c075)
Backport of https://github.com/canonical/snap-openstack-hypervisor/pull/105