### PR TITLE
backport: libvirt: add "kernel-module-control" plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -91,6 +91,7 @@ apps:
       - hardware-observe
       - hugepages-control
       - kvm
+      - kernel-module-control
       - kernel-module-observe
       - process-control
       - mount-observe


### PR DESCRIPTION
Attaching ports with hardware offloading currently fails as Libvirt attempts to load the VF driver:

   Failed to load PCI driver module mlx5_vfio_pci: modprobe:
   ERROR: could not insert 'mlx5_vfio_pci': Operation not permitted

To address this, we'll leverage the "kernel-module-control" snap interface.

We previously reverted this change in order to do some further testing after experiencing some inconsistent snap behavior. However, it turns out that we really need this plug in order for hardware offloading to work.

(cherry picked from commit 4a44400cc60fc1e81bfef1af8d16ebd5c505fd0c)
Backport of: https://github.com/canonical/snap-openstack-hypervisor/pull/94