### PR TITLE
Add DPDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ OVS DPDK settings:
 * `network.ovs-dpdk-enabled`: specifies whether ovs should initialize DPDK support
 * `network.ovs-memory`: comma separated list of integers that represent the memory (in MB)
   from each NUMA node to be used by OVS for DPDK
-* `network.ovs-pmd-cpu-mask` comma separated list of integers specifying which CPUs
-  should be used by OVS to run the PMD threads
-* `network.ovs-lcore-mask` comma separated list of integers specifying which CPUs
-  should be used by OVS to run the lcore threads
+* `network.ovs-pmd-cpu-mask` bit mask specifying which CPUs should be used by OVS to run
+  the PMD threads. For example, 0xF0 would enable the 5,6,7,8 cores.
+* `network.ovs-lcore-mask` bit mask specifying which CPUs should be used by OVS to run
+  the lcore threads. For example, 0xF0 would enable the 5,6,7,8 cores.
 
 SR-IOV agent settings:
 

--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ All of the above options must be provided as base64 encoded strings.
 OVS DPDK settings:
 
 * `network.ovs-dpdk-enabled`: specifies whether ovs should initialize DPDK support
-* `network.ovs-memory`: comma separated list of integers that represent the memory (in GB)
-  from each numa node to be used by OVS for DPDK
+* `network.ovs-memory`: comma separated list of integers that represent the memory (in MB)
+  from each NUMA node to be used by OVS for DPDK
 * `network.ovs-pmd-cpu-mask` comma separated list of integers specifying which CPUs
   should be used by OVS to run the PMD threads
 * `network.ovs-lcore-mask` comma separated list of integers specifying which CPUs

--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ TLS configuration for OVN can also be supplied via snap configuration:
 
 All of the above options must be provided as base64 encoded strings.
 
+OVS DPDK settings:
+
+* `network.ovs-dpdk-enabled`: specifies whether ovs should initialize DPDK support
+* `network.ovs-memory`: comma separated list of integers that represent the memory (in GB)
+  from each numa node to be used by OVS for DPDK
+* `network.ovs-pmd-cpu-mask` comma separated list of integers specifying which CPUs
+  should be used by OVS to run the PMD threads
+* `network.ovs-lcore-mask` comma separated list of integers specifying which CPUs
+  should be used by OVS to run the lcore threads
+
 SR-IOV agent settings:
 
 * `network.sriov-nic-exclude-devices`: SR-IOV excluded VFs

--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -19,6 +19,7 @@ import stat
 import string
 import subprocess
 import time
+import typing
 import uuid
 import xml.etree.ElementTree
 from pathlib import Path
@@ -639,16 +640,70 @@ def _delete_iptable_postrouting_rule(comment: str) -> None:
         logging.info(f"Error in deletion of IPtable rule: {e.stderr}")
 
 
-def _ovs_vsctl_set(table: str, record: str, settings: dict[str, str]) -> None:
+def _ovs_vsctl_set(table: str, record: str, column: str, settings: dict[str, str]) -> None:
     if not settings:
         logging.warning("No ovs values to set, skipping...")
         return
 
     cmd = ["ovs-vsctl", "--retry", "set", table, record]
     for key, value in settings.items():
-        cmd.append(f"{key}={value}")
+        cmd.append(f"{column}:{key}={value}")
 
     subprocess.check_call(cmd)
+
+
+def _parse_ovsdb_data(data: list[str, typing.Any]) -> typing.Any:
+    """Parse OVSDB data.
+
+    https://tools.ietf.org/html/rfc7047#section-5.1
+    """
+    if isinstance(data, list) and len(data) == 2:
+        if data[0] == "set":
+            return [_parse_ovsdb_data(element) for element in data[1]]
+        if data[0] == "map":
+            return {_parse_ovsdb_data(key): _parse_ovsdb_data(value) for key, value in data[1]}
+        if data[0] == "uuid":
+            return uuid.UUID(data[1])
+    return data
+
+
+def _ovs_vsctl_list_table(table: str, record: str, columns: list[str] | None) -> dict:
+    try:
+        cmd = ["ovs-vsctl", "--retry", "--format", "json", "--if-exists"]
+        if columns:
+            cmd += ["--columns=%s" % ",".join(columns)]
+        cmd += ["list", table, record]
+        out = subprocess.check_output(cmd).decode()
+    except subprocess.CalledProcessError:
+        # The columns may not exist.
+        # --if-exists only applies to the record, not the columns.
+        return {}
+
+    raw_json = json.loads(out)
+    headings = raw_json["headings"]
+    data = raw_json["data"]
+
+    parsed = {}
+    # We've requested a single record.
+    for record in data:
+        for position, heading in enumerate(headings):
+            parsed[heading] = _parse_ovsdb_data(record[position])
+
+    return parsed
+
+
+def _ovs_vsctl_set_check(table: str, record: str, column: str, settings: dict[str, str]) -> bool:
+    """Apply the specified settings and return a boolean stating if changes were made."""
+    config_changed = False
+    current_values = _ovs_vsctl_list_table(table, record, [column]).get(column, {})
+    for key, new_val in settings.items():
+        if key not in current_values or str(new_val) != str(current_values[key]):
+            config_changed = True
+
+    if config_changed:
+        _ovs_vsctl_set(table, record, column, settings)
+
+    return config_changed
 
 
 def _configure_ovn_base(snap: Snap, context: dict) -> None:
@@ -676,12 +731,13 @@ def _configure_ovn_base(snap: Snap, context: dict) -> None:
     _ovs_vsctl_set(
         "open",
         ".",
+        "external_ids",
         {
-            "external_ids:ovn-encap-type": "geneve",
-            "external_ids:ovn-encap-ip": ovn_encap_ip,
-            "external_ids:system-id": system_id,
-            "external_ids:ovn-match-northd-version": "true",
-            "external_ids:ovn-bridge-datapath-type": datapath_type,
+            "ovn-encap-type": "geneve",
+            "ovn-encap-ip": ovn_encap_ip,
+            "system-id": system_id,
+            "ovn-match-northd-version": "true",
+            "ovn-bridge-datapath-type": datapath_type,
         },
     )
 
@@ -693,7 +749,7 @@ def _configure_ovn_base(snap: Snap, context: dict) -> None:
         logging.info("OVN SB connection URL not configured, skipping.")
         return
 
-    _ovs_vsctl_set("open", ".", {"external_ids:ovn-remote": sb_conn})
+    _ovs_vsctl_set("open", ".", "external_ids", {"ovn-remote": sb_conn})
 
 
 def _dpdk_supported() -> bool:
@@ -723,11 +779,17 @@ def _get_dpdk_pmd_dir(snap: Snap) -> str:
     return pmd_dirs[0]
 
 
-def _configure_ovs(snap: Snap, context: dict) -> None:
+def _configure_ovs(snap: Snap, context: dict) -> bool:
+    """Configure OVS and return a boolean stating whether there were any changes made."""
+    config_changed = False
+
+    # See the "Open_vSwitch TABLE" section of "man ovs-vswitchd.conf.db" for more
+    # details.
     hw_offloading = context.get("network", {}).get("hw_offloading")
     if hw_offloading:
         logging.info("Configuring Open vSwitch hardware offloading.")
-        _ovs_vsctl_set("open", ".", {"other_config:hw-offload": "true"})
+        if _ovs_vsctl_set_check("Open_vSwitch", ".", "other_config", {"hw-offload": "true"}):
+            config_changed = True
     else:
         logging.info("No whitelisted SR-IOV devices with hardware offloading.")
 
@@ -739,22 +801,25 @@ def _configure_ovs(snap: Snap, context: dict) -> None:
 
     if ovs_dpdk_enabled and _dpdk_supported():
         logging.info("Configuring Open vSwitch to use DPDK.")
-        dpdk_settings["other_config:dpdk-init"] = "try"
+        dpdk_settings["dpdk-init"] = "try"
         # Point DPDK to the right PMD plugin directory.
         pmd_lib_dir = _get_dpdk_pmd_dir(snap)
-        dpdk_settings["other_config:dpdk-extra"] = f"-d {pmd_lib_dir}"
+        dpdk_settings["dpdk-extra"] = f"-d {pmd_lib_dir}"
     if ovs_memory:
-        dpdk_settings["other_config:dpdk-socket-mem"] = ovs_memory
+        dpdk_settings["dpdk-socket-mem"] = ovs_memory
     if ovs_lcore_mask:
-        dpdk_settings["other_config:dpdk-lcore-mask"] = ovs_lcore_mask
+        dpdk_settings["dpdk-lcore-mask"] = ovs_lcore_mask
     if ovs_pmd_cpu_mask:
-        dpdk_settings["other_config:pmd-cpu-mask"] = ovs_pmd_cpu_mask
+        dpdk_settings["pmd-cpu-mask"] = ovs_pmd_cpu_mask
 
     if dpdk_settings:
         logging.debug("Applying DPDK settings: %s", dpdk_settings)
-        _ovs_vsctl_set("Open_vSwitch", ".", dpdk_settings)
+        if _ovs_vsctl_set_check("Open_vSwitch", ".", "other_config", dpdk_settings):
+            config_changed = True
     else:
         logging.debug("No OVS DPDK settings provided.")
+
+    return config_changed
 
 
 def _list_bridge_ifaces(bridge_name: str) -> list:
@@ -1817,12 +1882,15 @@ def configure(snap: Snap) -> None:
 
     _configure_ovn_base(snap, context)
     _configure_ovn_external_networking(snap, context)
-    _configure_ovs(snap, context)
+    ovs_restart_required = _configure_ovs(snap, context)
 
-    logging.info("Restarting ovs-vswitchd to apply changes.")
-    ovs_vswitchd_service = snap.services.list()["ovs-vswitchd"]
-    ovs_vswitchd_service.stop()
-    ovs_vswitchd_service.start(enable=True)
+    if ovs_restart_required:
+        logging.info("Restarting ovs-vswitchd to apply changes.")
+        ovs_vswitchd_service = snap.services.list()["ovs-vswitchd"]
+        ovs_vswitchd_service.stop()
+        ovs_vswitchd_service.start(enable=True)
+    else:
+        logging.info("ovs-vswitchd restart not required.")
 
     _configure_kvm(snap)
     _configure_monitoring_services(snap)

--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -695,7 +695,13 @@ def _configure_ovn_base(snap: Snap, context: dict) -> None:
 
 
 def _get_dpdk_pmd_dir(snap: Snap):
-    glob_pattern = snap.paths.snap / Path("usr/lib/x86_64-linux-gnu/dpdk/pmds-*")
+    # We'll need the "current" symlink so that the path remains valid during upgrades.
+    glob_pattern = (
+        Path("/snap")
+        / Path(snap.name)
+        / Path("current")
+        / Path("/usr/lib/x86_64-linux-gnu/dpdk/pmds-*")
+    )
     pmd_dirs = os.glob(glob_pattern)
     if not pmd_dirs:
         raise Exception("Unable to locate dpdk pmd plugin directory: %s" % glob_pattern)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -245,6 +245,7 @@ apps:
       - network-control
       - network-observe
       - microstack-support
+      - firewall-control
 
   neutron-sriov-nic-agent:
     command: 'bin/neutron-sriov-nic-agent-service'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -472,7 +472,6 @@ parts:
       - --disable-user
       - --disable-linux-user
       - --disable-bsd-user
-      - --disable-vhost-user
       - --disable-xen
       - --disable-werror
       - --prefix=/usr

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,6 +28,7 @@ environment:
   OVS_PKGDATADIR: $SNAP/usr/share/openvswitch
   OVS_BINDIR: $SNAP/usr/bin
   OVS_SBINDIR: $SNAP/usr/sbin
+  RUNTIME_DIRECTORY: $SNAP_COMMON/run
 
 platforms:
   amd64:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -646,8 +646,10 @@ parts:
       - openvswitch-switch
       - on amd64:
         - openvswitch-switch-dpdk
+        - librte-meta-all
       - on arm64:
         - openvswitch-switch-dpdk
+        - librte-meta-all
       - ovn-host
     override-build: |
       craftctl default


### PR DESCRIPTION
This PR will allow configuring OVS to use DPDK, introducing the following settings:

* `network.ovs-dpdk-enabled`: specifies whether ovs should initialize DPDK support
* `network.ovs-memory`: comma separated list of integers that represent the memory (in MB) from each numa node to be used by OVS for DPDK
* `network.ovs-pmd-cpu-mask` bit mask specifying which CPUs should be used by OVS to run the PMD threads. For example, 0xF0 would enable the 5,6,7,8 cores.
* `network.ovs-lcore-mask` bit mask specifying which CPUs should be used by OVS to run the lcore threads. For example, 0xF0 would enable the 5,6,7,8 cores.


If DPDK is enabled, the OVS bridges will be set to use the `netdev` data path instead of `system.

At the same time, we'll enable `vhost-user` support when building Qemu.

neutron-k8s charm patch: https://review.opendev.org/c/openstack/sunbeam-charms/+/957016

TODO:

* ~~update `ovs-vswitchd` permissions to accommodate DPDK~~
  * https://github.com/canonical/snapd/pull/15832
* configure physical ports to use dpdk (e.g. the external interface)