### PR TITLE
Allow disabling dpdk

### DIFF
--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -805,6 +805,9 @@ def _configure_ovs(snap: Snap, context: dict) -> bool:
         # Point DPDK to the right PMD plugin directory.
         pmd_lib_dir = _get_dpdk_pmd_dir(snap)
         dpdk_settings["dpdk-extra"] = f"-d {pmd_lib_dir}"
+    else:
+        dpdk_settings["dpdk-init"] = "false"
+
     if ovs_memory:
         dpdk_settings["dpdk-socket-mem"] = ovs_memory
     if ovs_lcore_mask:

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -105,6 +105,7 @@ class TestHooks:
     ):
         """Tests the configure hook."""
         mock_template = mocker.Mock()
+        mocker.patch.object(hooks, "_ovs_vsctl_set_check")
         mocker.patch.object(hooks, "_get_template", return_value=mock_template)
         mock_write_text = mocker.patch.object(hooks.Path, "write_text")
         mock_chmod = mocker.patch.object(hooks.Path, "chmod")
@@ -722,6 +723,7 @@ def test_nova_conf_cpu_pinning_injection(
     mocker.patch("openstack_hypervisor.hooks.Path.write_text")
     mocker.patch("openstack_hypervisor.hooks.Path.chmod")
     for fn in [
+        "_configure_ovs",
         "_configure_ovn_base",
         "_configure_ovn_external_networking",
         "_configure_kvm",


### PR DESCRIPTION
We currently allow enabling dpdk but we aren't modifying the "dpdk-init" setting if dpdk is subsequently disabled by the user.

This change will explicitly set "dpdk-init" to "false" if DPDK is disabled or unavailable.

The other DPDK settings will be ignored by OVS if DPDK is disabled.