### PR TITLE
Add DPDK snap permissions

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -76,6 +76,7 @@ apps:
     plugs:
       - network
       - network-observe
+      - network-setup-control
       - hardware-observe
 
   # Libvirt
@@ -648,9 +649,11 @@ parts:
       - on amd64:
         - openvswitch-switch-dpdk
         - librte-meta-all
+        - driverctl
       - on arm64:
         - openvswitch-switch-dpdk
         - librte-meta-all
+        - driverctl
       - ovn-host
     override-build: |
       craftctl default
@@ -753,11 +756,14 @@ hooks:
     plugs:
       - network
       - network-control
+      - network-setup-control
       - hardware-observe
+      - kernel-module-control
       - firewall-control
       - microstack-support
       - kvm
       - epa-info
+      - etc-driverctl
   connect-slot-hypervisor-config:
     plugs:
       - network
@@ -769,3 +775,8 @@ plugs:
     interface: content
     content: epa-info
     target: $SNAP_DATA
+  # Required in order to persistently bind drivers such as vfio-pci.
+  etc-driverctl:
+    interface: system-files
+    write:
+    - /etc/driverctl.d


### PR DESCRIPTION
This PR adds the snap permissions required for physical DPDK port handling, introduced here:

https://github.com/canonical/snap-openstack-hypervisor/pull/111

We're using a separate PR since the new privileges will have to be approved by the snap team.

We need to hold this until the following request gets approved: https://forum.snapcraft.io/t/request-network-setup-control-and-system-files-openstack-hypervsior-snap/48415