### PR TITLE
sr-iov: avoid duplicate VF specs

### DIFF
--- a/openstack_hypervisor/pci.py
+++ b/openstack_hypervisor/pci.py
@@ -172,12 +172,13 @@ def apply_exclusion_list(pci_device_specs: list[dict], excluded_devices: list[st
         # a granular whitelist.
         matched_excluded_devices = False
         for device in all_pci_devices:
+            # We won't pass "parent_addr", the VF list gets populated separately and
+            # we want to avoid duplicates, see "process_whitelisted_sriov_pfs".
             match = pci_spec.match(
                 {
                     "vendor_id": device["vendor_id"].replace("0x", ""),
                     "product_id": device["product_id"].replace("0x", ""),
                     "address": device["address"],
-                    "parent_addr": device["physfn_address"],
                 }
             )
             if match:


### PR DESCRIPTION
At the moment, nova.conf contains duplicate PCI device specs for whitelisted SR-IOV VF.

The reason is that for each whitelisted PF,
"process_whitelisted_sriov_pfs" adds the VFs to the whitelist and the PF to the exclusion list.

"apply_exclusion_list" then processes the PF spec, sees that the device is excluded but also detects the matching VFs, which are added again to the whitelist.

We'll avoid this by modifying "apply_exclusion_list" to ignore parent PFs since the list of VFs is populated separately.