### PR TITLE
[BACKPORT TO CARACAL] Implement VM shutdown listener with socket interface and monitoring

### DIFF
--- a/bin/pre-evacuation-setup-service
+++ b/bin/pre-evacuation-setup-service
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+import enum
+import json
+import logging
+import os
+import socket
+import subprocess
+import time
+from typing import Dict
+
+from pydantic import BaseModel, Field, field_validator
+from snaphelpers import Snap
+
+SOCKET_PATH = os.path.join(os.environ["SNAP_DATA"], "data", "shutdown.sock")
+
+PROTOCOL_VERSION = "1.0"
+
+
+class NetworkStatus(enum.Enum):
+    """Enum for network interface status"""
+    NIC_DOWN = "nic-down"
+
+
+class NetworkStatusMessage(BaseModel):
+    """Pydantic model for network status messages"""
+    version: str = Field(description="Protocol version")
+    timestamp: float = Field(description="Message timestamp")
+    status: str = Field(description="Network status")
+
+    @field_validator('version')
+    @classmethod
+    def validate_version(cls, v):
+        if v != PROTOCOL_VERSION:
+            logging.warning(f"Incompatible protocol version: {v}, expected: {PROTOCOL_VERSION}")
+        return v
+
+    @field_validator('status')
+    @classmethod
+    def validate_status(cls, v):
+        try:
+            return NetworkStatus(v).value
+        except ValueError:
+            raise ValueError(f"Invalid status: {v}. Must be one of: {', '.join([s.value for s in NetworkStatus])}")
+
+
+def stop_nova_compute():
+    """
+    Stop the nova-compute service to allow VM evacuation,
+    but only if it is currently running.
+    """
+    try:
+        snap = Snap()
+        services = snap.services.list()
+
+        if 'nova-compute' in services:
+            service = services['nova-compute']
+
+            if service.active:
+                logging.info("nova-compute is active. Proceeding to stop the service...")
+                service.stop()
+                logging.info("nova-compute service stopped successfully.")
+            else:
+                logging.info("nova-compute service is already stopped. No action needed.")
+        else:
+            logging.warning("nova-compute service not found in the list of snap services")
+
+    except Exception as e:
+        logging.error(f"Unexpected error during nova-compute stop: {e}")
+
+
+def shutdown_vms():
+    """
+    Shut down all running VMs using virsh.
+    """
+    logging.info("Initiating shutdown of all running VMs...")
+    result = subprocess.run(
+        ["virsh", "list", "--name"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True
+    )
+    vm_names = [line.strip() for line in result.stdout.strip().splitlines() if line.strip()]
+
+    if not vm_names:
+        logging.info("No running VMs found.")
+        return
+
+    for vm in vm_names:
+        logging.info(f"Shutting down VM: {vm}")
+        try:
+            subprocess.run(["virsh", "shutdown", vm], check=True, timeout=30)
+        except subprocess.TimeoutExpired:
+            logging.error(f"Timeout: VM '{vm}' did not shutdown in 30 seconds.")
+        except subprocess.CalledProcessError as e:
+            logging.error(f"Error during VM shutdown: {e.stderr.strip()}")
+        except Exception as e:
+            logging.error(f"Unexpected error: {e}")
+
+    logging.info("Shutdown commands sent to all VMs.")
+
+
+def handle_network_status(data: Dict) -> str:
+    """Handle network status messages and take appropriate actions
+
+    Args:
+        data: The validated message data
+
+    Returns:
+        Response message to send back to the client
+    """
+    status_value = data["status"]
+    status = NetworkStatus(status_value)
+    logging.info(f"Received network status update: {status_value}")
+
+    if status == NetworkStatus.NIC_DOWN:
+        logging.info("Network interface down detected, initiating evacuation procedure")
+
+        stop_nova_compute()
+        shutdown_vms()
+
+        return json.dumps({
+            "status": "success",
+            "message": "Evacuation procedure initiated",
+            "timestamp": time.time()
+        })
+
+    else:
+        logging.warning(f"Received unknown network status: {status_value}")
+
+        return json.dumps({
+            "status": "error",
+            "message": f"Unknown network status: {status_value}",
+            "timestamp": time.time()
+        })
+
+
+def run_listener():
+    logging.basicConfig(level=logging.INFO)
+
+    os.makedirs(os.path.dirname(SOCKET_PATH), exist_ok=True)
+    if os.path.exists(SOCKET_PATH):
+        os.remove(SOCKET_PATH)
+
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server_sock:
+        server_sock.bind(SOCKET_PATH)
+        os.chmod(SOCKET_PATH, 0o666)
+        server_sock.listen()
+        logging.info(f"Listening on Unix socket: {SOCKET_PATH}")
+        logging.info(f"Using protocol version: {PROTOCOL_VERSION}")
+
+        while True:
+            conn, _ = server_sock.accept()
+            with conn:
+                data = conn.recv(1024)
+                if not data:
+                    continue
+
+                raw_message = data.decode().strip()
+                logging.debug(f"Received raw message: {raw_message}")
+
+                try:
+                    json_data = json.loads(raw_message)
+                    message = NetworkStatusMessage.model_validate(json_data)
+                    validated_data = message.model_dump()
+
+                    response = handle_network_status(validated_data)
+                    conn.sendall(response.encode())
+
+                except ValueError as e:
+                    logging.error(f"Validation error: {e}")
+                    error_response = json.dumps({
+                        "status": "error",
+                        "message": f"Schema validation failed: {str(e)}",
+                        "timestamp": time.time()
+                    })
+                    conn.sendall(error_response.encode())
+                except Exception as e:
+                    logging.error(f"Error processing message: {e}")
+                    error_response = json.dumps({
+                        "status": "error",
+                        "message": f"Server error: {str(e)}",
+                        "timestamp": time.time()
+                    })
+                    conn.sendall(error_response.encode())
+
+
+if __name__ == "__main__":
+    run_listener()

--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -130,7 +130,7 @@ MONITORING_SERVICES = [
     "ovs-exporter",
 ]
 
-MASAKARI_SERVICES = ["masakari-instancemonitor"]
+MASAKARI_SERVICES = ["masakari-instancemonitor", "pre-evacuation-setup"]
 
 
 def _generate_secret(length: int = DEFAULT_SECRET_LENGTH) -> str:

--- a/openstack_hypervisor/services.py
+++ b/openstack_hypervisor/services.py
@@ -163,6 +163,19 @@ class MasakariInstanceMonitorService(OpenStackService):
 masakari_instancemonitor = partial(entry_point, MasakariInstanceMonitorService)
 
 
+class PreEvacuationSetupService(OpenStackService):
+    """A python service object used to run the pre-evacuation-setup daemon."""
+
+    conf_files = []
+    conf_dirs = []
+    extra_args = []
+
+    executable = Path("usr/bin/pre-evacuation-setup-service")
+
+
+pre_evacuation_setup = partial(entry_point, PreEvacuationSetupService)
+
+
 class OVSDBServerService:
     """A python service object used to run the ovsdb-server daemon."""
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -283,6 +283,16 @@ apps:
       - firewall-control
       - microstack-support
 
+  pre-evacuation-setup:
+    command: 'bin/pre-evacuation-setup-service'
+    after: [libvirtd]
+    daemon: simple
+    plugs:
+      - network
+      - network-bind
+      - firewall-control
+      - microstack-support
+
   libvirt-exporter:
     daemon: simple
     install-mode: disable
@@ -772,6 +782,13 @@ slots:
     source:
       write:
         - $SNAP_DATA/run/hypervisor-config
+
+  consul-socket:
+    interface: content
+    content: consul-unix-sock
+    source:
+      write:
+        - $SNAP_DATA/data
 
 hooks:
   install:

--- a/templates/masakarimonitors.conf.j2
+++ b/templates/masakarimonitors.conf.j2
@@ -24,6 +24,7 @@ cafile = {{ snap_common }}/etc/ssl/certs/receive-ca-bundle.pem
 {% endif -%}
 service_token_roles = {{ identity.admin_role }}
 service_token_roles_required = True
-
+[host]
+monitoring_samples=4
 [libvirt]
 # connection_uri = qemu:///system


### PR DESCRIPTION
BACKPORT Masakari TCP Health check to caracal

- Added a Unix domain socket listener service to handle external VM shutdown commands
- Integrated nova-compute stop and virsh shutdown logic for safe instance evacuation
- Introduced timeout handling for VM shutdowns to ensure robustness
- Refactored and improved logging for better observability
- Added monitoring sample config under [host] group
- Set correct permissions, paths, and snap plugs/slots to enable service communication

(cherry picked from commit c4eef0e0bb7604fda9c818734a131a22f9fa33fa)