### PR TITLE
Ensure qemu binary data is available in the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -364,6 +364,7 @@ parts:
     plugin: autotools
     stage-packages:
       - seabios
+      - qemu-system-data
       - ipxe-qemu
       # UEFI Support, required on arm64
       - on arm64:


### PR DESCRIPTION
Binary data such as `seabios.bin` or `kvmvapic.bin`, which are necessary for more advanced features of nova/libvirt/qemu are missing from the hypervisor.

Include the package `qemu-system-data` instead of building because:
- package has not dependency, only brings bios binaries
- build the binaries requires the correct git submodules setup, which are not available directly from the debian package repo
- no value in being rebuilt specifically for the snap