### PR TITLE
Drop ovn setting ovn-match-northd-version

### DIFF
--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -738,7 +738,6 @@ def _configure_ovn_base(snap: Snap, context: dict) -> None:
             "ovn-encap-type": "geneve",
             "ovn-encap-ip": ovn_encap_ip,
             "system-id": system_id,
-            "ovn-match-northd-version": "true",
             "ovn-bridge-datapath-type": datapath_type,
         },
     )


### PR DESCRIPTION
Rolling upgrades are supported by OVN from
22.03 and so the setting ovn-match-northd-version
is no more required. [1]

Having this setting wont allow registering chassis in southbound database if there is a mismatch
between OVN versions in northd and ovn-controller [2]

Do not set ovn config ovn-match-northd-version

[1] https://docs.ovn.org/en/latest/intro/install/ovn-upgrades.html
[2] https://bugs.launchpad.net/snap-openstack/+bug/2126901