### PR TITLE
tics: add prerequisite packages

### DIFF
--- a/.github/workflows/TiCS.yml
+++ b/.github/workflows/TiCS.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
     TICS:
-      runs-on: [self-hosted, linux, amd64, tiobe]
+      runs-on: [self-hosted, linux, amd64, tiobe, noble]
       steps:
         - name: Checkout
           uses: actions/checkout@v4
@@ -28,6 +28,7 @@ jobs:
           run: |
             uv sync --all-extras
             source .venv/bin/activate
+            echo PATH=$PATH >> $GITHUB_ENV
 
         - name: TICS
           uses: tiobe/tics-github-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ dev= [
 tics= [
     "python-novaclient",
     "libvirt-python",
+    "pylint",
+    "flake8",
 ]
 
 [project.urls]


### PR DESCRIPTION
Add packages required for tics in pyporject.toml
Pass PATH env to GITHUB_PATH so that uv venv is
considered in tics execution
Move github runner execution to noble