### PR TITLE
Ensure Nova reaches Cinder through internal API

### DIFF
--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -116,9 +116,7 @@ lock_path = {{ snap_common }}/lock
 ovsdb_connection = {{ network.ovs_socket_path }}
 
 [cinder]
-service_type = volumev3
-service_name = cinderv3
-valid_interfaces = internal
+catalog_info = volumev3::internalURL
 region_name = {{ identity.region_name }}
 {% if ca and ca.bundle -%}
 cafile = {{ snap_common }}/etc/ssl/certs/receive-ca-bundle.pem

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -65,7 +65,7 @@ def test_nova_clients_use_internal_interface():
 
     assert "[cinder]" in output
     assert "valid_interfaces = internal" in output
-    assert output.count("valid_interfaces = internal") == 2
+    assert output.count("valid_interfaces = internal") == 1
     assert "[neutron]" in output
     assert "[placement]" in output
     assert "[barbican]" in output


### PR DESCRIPTION
Cinder configuration option on Nova is expecting
the option catalog_info instead to provide information about the service to Nova.
This removes the unnecessary config options.

Closes-Bug: #176

This follow the documentation provided by Openstack for Nova : 
https://docs.openstack.org/nova/2024.1/configuration/config.html#cinder