### PR TITLE
fix: use enable-patchelf to fix libvirt_iohelper missing shared libra…

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -671,6 +671,15 @@ parts:
       rsync --remove-source-files -arhvP $CRAFT_PART_INSTALL/snap/$CRAFT_PROJECT_NAME/current/usr/* $CRAFT_PART_INSTALL/usr/
       rm -rf $CRAFT_PART_INSTALL/snap/$CRAFT_PROJECT_NAME/current/usr
 
+    # enable-patchelf sets RPATH on libvirt-built ELF files so that shared
+    # libraries staged under usr/lib/<triplet> are found at runtime without
+    # LD_LIBRARY_PATH. This is required because libvirt_iohelper is spawned
+    # by virFileWrapperFdNew() with a minimal environment (no LD_LIBRARY_PATH),
+    # causing the resolution chain libvirt.so.0 -> libxml2.so.2 -> libicuuc.so.74
+    # to fail with "cannot open shared object file" on server suspend/resume.
+    build-attributes:
+      - enable-patchelf
+
   templates:
     source: templates/
     plugin: dump


### PR DESCRIPTION
…ries

libvirt_iohelper is spawned by virFileWrapperFdNew() with a minimal environment containing only LIBVIRT_LOG_OUTPUTS=1:stderr. The parent libvirtd's LD_LIBRARY_PATH is never propagated to the child, so staged shared libraries (libxml2, libyajl, libicuuc, etc.) in usr/lib/x86_64-linux-gnu/ are not found, causing server suspend to fail:

   operation failed: .../libvirt_iohelper: error while loading shared
   libraries: libxml2.so.2: cannot open shared object file: No such
   file or directory

Fix by adding build-attributes: [enable-patchelf] to the libvirt part. Snapcraft sets RPATH (old DT_RPATH tag, not RUNPATH) with $ORIGIN on libvirt-built ELF files, enabling the dynamic linker to locate staged libraries transitively — without requiring a build-time patchelf script.

Fixes: https://bugs.launchpad.net/snap-openstack/+bug/2150555

Assisted-by: Claude:claude-4.6-sonnet