### PR TITLE
Fix/2026.1 build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -350,6 +350,8 @@ apps:
 parts:
   kvm-support:
     plugin: nil
+    build-attributes:
+      - enable-patchelf
     stage-packages:
     - on amd64:
       - msr-tools
@@ -385,9 +387,7 @@ parts:
       -X ${PROJECT}/${PKG_DIR}.buildUser=$BUILD_USER \
       -X ${PROJECT}/${PKG_DIR}.buildDate=$BUILD_DATE" \
       ./cmd/ovs_exporter/*.go
-    override-prime: |
-      craftctl default
-      install -D $SNAPCRAFT_PART_SRC/../build/bin/ovs-exporter bin/ovs-exporter
+      install -D ./bin/${BINARY} $CRAFT_PART_INSTALL/bin/${BINARY}
 
   qemu:
     source: https://git.launchpad.net/ubuntu/+source/qemu
@@ -395,6 +395,8 @@ parts:
     source-branch: ubuntu/resolute-devel
     source-depth: 1
     plugin: autotools
+    build-attributes:
+      - enable-patchelf
     stage-packages:
       - ipxe-qemu
       - on arm64:
@@ -515,11 +517,6 @@ parts:
 
       # Install keymaps as the qemu build process does not!
       install -Dp -m0644 -t $CRAFT_PART_INSTALL/usr/share/qemu/keymaps $(ls -1 $CRAFT_PART_SRC/pc-bios/keymaps/* | fgrep -v /meson.build)
-    override-prime: |
-      craftctl default
-      # execstack is no longer available in Ubuntu 26.04 (removed with prelink).
-      # Modern toolchains produce binaries with correct PT_GNU_STACK by default,
-      # so clearing executable stack flags manually is no longer necessary.
 
   # note(gboutry): isolate qemu firmware data to prevent its dependencies to be pulled into the qemu part.
   qemu-firmware-data:
@@ -544,6 +541,8 @@ parts:
     after:
       - qemu
     plugin: meson
+    build-attributes:
+      - enable-patchelf
     build-packages:
     - libxml2-dev
     - libxml-libxml-perl
@@ -693,20 +692,6 @@ parts:
       rm -rf $CRAFT_PART_INSTALL/snap/$CRAFT_PROJECT_NAME/current/usr
       # purge dangling symlinks from stage-packages
       rm -f $CRAFT_PART_INSTALL/usr/bin/on_ac_power
-    override-prime: |
-      craftctl default
-      # on_ac_power is a symlink into the host filesystem (/sbin/on_ac_power);
-      # remove it here (prime phase) to ensure it never lands in the snap.
-      rm -f $CRAFT_PRIME/usr/bin/on_ac_power
-
-    # enable-patchelf sets RPATH on libvirt-built ELF files so that shared
-    # libraries staged under usr/lib/<triplet> are found at runtime without
-    # LD_LIBRARY_PATH. This is required because libvirt_iohelper is spawned
-    # by virFileWrapperFdNew() with a minimal environment (no LD_LIBRARY_PATH),
-    # causing the resolution chain libvirt.so.0 -> libxml2.so.2 -> libicuuc.so.74
-    # to fail with "cannot open shared object file" on server suspend/resume.
-    build-attributes:
-      - enable-patchelf
 
   templates:
     source: templates/
@@ -722,6 +707,8 @@ parts:
 
   networking:
     plugin: nil
+    build-attributes:
+      - enable-patchelf
     stage-packages:
       - openvswitch-switch
       - on amd64:
@@ -741,11 +728,15 @@ parts:
 
   apache2-webdav:
     plugin: nil
+    build-attributes:
+      - enable-patchelf
     stage-packages:
       - apache2
 
   openstack:
     plugin: nil
+    build-attributes:
+      - enable-patchelf
     build-packages:
       - patch
       - python3-pip
@@ -795,9 +786,8 @@ parts:
       rm -rf $CRAFT_PART_INSTALL/usr/bin/rst2*
       # Install webdav4 for Nova's HttpDriver (not available as Debian package)
       pip3 install --target=$CRAFT_PART_INSTALL/usr/lib/python3/dist-packages webdav4
-    override-prime: |
-      craftctl default
-      pushd "$CRAFT_PRIME/usr/lib/python3/dist-packages"
+
+      pushd "$CRAFT_PART_INSTALL/usr/lib/python3/dist-packages"
       path="$CRAFT_PROJECT_DIR/snap/patches/nova/0001-remotefs-http-driver.patch"
       # Unapply patch, ignore on failure
       patch -p1 --reverse --forward --quiet --batch --reject-file=/dev/null --input "$path" || true
@@ -806,6 +796,8 @@ parts:
 
   openstack-hypervisor:
     plugin: uv
+    build-attributes:
+      - enable-patchelf
     source: .
     build-snaps: [astral-uv]
     build-packages:
@@ -826,6 +818,8 @@ parts:
 
   libvirt-exporter:
     plugin: go
+    build-attributes:
+      - enable-patchelf
     source-tag: 2.3.3
     source-type: git
     source: https://github.com/Tinkoff/libvirt-exporter
@@ -841,6 +835,8 @@ parts:
   # gets backported.
   netplan:
     plugin: nil
+    build-attributes:
+      - enable-patchelf
     source-tag: main
     source-type: git
     source: https://github.com/canonical/netplan
@@ -886,6 +882,24 @@ parts:
       meson setup _build -Dunit_testing=false --prefix=/usr
       meson compile -C _build
       meson install -C _build --destdir $CRAFT_PART_INSTALL
+
+  elf-rpath-fixes:
+    plugin: nil
+    after:
+      - libvirt-exporter
+      - netplan
+      - openstack-hypervisor
+      - qemu-firmware-data
+    build-packages:
+      - patchelf
+    override-prime: |
+      craftctl default
+
+      numpy_lapack_lite="$CRAFT_PRIME/usr/lib/python3/dist-packages/numpy/linalg/lapack_lite.cpython-314-x86_64-linux-gnu.so"
+      numpy_lapack_lite_rpath='$ORIGIN/../../../../x86_64-linux-gnu/blas:$ORIGIN/../../../../x86_64-linux-gnu:$ORIGIN/../../../../x86_64-linux-gnu/lapack'
+      if [ -f "$numpy_lapack_lite" ]; then
+          patchelf --force-rpath --set-rpath "$numpy_lapack_lite_rpath" "$numpy_lapack_lite"
+      fi
 
 slots:
   hypervisor-config:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -644,6 +644,7 @@ parts:
     - -Dlibdir=/snap/$CRAFT_PROJECT_NAME/current/usr/lib
     - -Dincludedir=/snap/$CRAFT_PROJECT_NAME/current/usr/include
     - -Dlocalstatedir=/var/snap/$CRAFT_PROJECT_NAME/common
+    - -Drunstatedir=/var/snap/$CRAFT_PROJECT_NAME/common/run
     - -Dsysconfdir=/var/snap/$CRAFT_PROJECT_NAME/common/etc
     override-build: |
       dpkg-source --before-build $CRAFT_PART_SRC

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -396,16 +396,10 @@ parts:
     source-depth: 1
     plugin: autotools
     stage-packages:
-      - seabios
-      - qemu-system-data
       - ipxe-qemu
-      # UEFI Support, required on arm64
       - on arm64:
-        - qemu-efi-aarch64
-        - qemu-efi-arm
         - libspice-server1
       - on amd64:
-        - ovmf
         - libspice-server1
       - libglut3.12 # provides libglut.so.3
       - libnuma1
@@ -510,6 +504,7 @@ parts:
       - --disable-bsd-user
       - --disable-xen
       - --disable-werror
+      - --python=/usr/bin/python3
       - --prefix=/usr
       - --localstatedir=/var/snap/$CRAFT_PROJECT_NAME/common
       - --sysconfdir=/var/snap/$CRAFT_PROJECT_NAME/common
@@ -525,6 +520,21 @@ parts:
       # execstack is no longer available in Ubuntu 26.04 (removed with prelink).
       # Modern toolchains produce binaries with correct PT_GNU_STACK by default,
       # so clearing executable stack flags manually is no longer necessary.
+
+  # note(gboutry): isolate qemu firmware data to prevent its dependencies to be pulled into the qemu part.
+  qemu-firmware-data:
+    after: [qemu]
+    plugin: nil
+    stage-packages:
+      - qemu-system-data
+      - on amd64:
+        - seabios
+        - ovmf
+      - on arm64:
+        - qemu-efi-aarch64
+    stage:
+      - usr/share
+      - -usr/share/doc
 
   libvirt:
     source: https://git.launchpad.net/ubuntu/+source/libvirt


### PR DESCRIPTION
On resolute, firmware data packages bring ubuntu-virt, which itselfs
brings a lot of un-wanted or already-present dependencies, which breaks
the build.

Drop qemu-efi-arm firware as it brings arm32 firmware, which is not
available on resolute, and we don't make use of.


Since we're staging libc6, ensure we're using the right binary libs for runtime.