### PR TITLE
Fix config for Nova-compute to use Barbican

### DIFF
--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -218,7 +218,7 @@ backend = barbican
 [barbican]
 auth_url = {{ identity.auth_url }}
 auth_type = password
-interface = internal
+barbican_endpoint_type = internal
 project_domain_name = {{ identity.project_domain_name }}
 user_domain_name = {{ identity.user_domain_name }}
 region_name = {{ identity.region_name }}
@@ -226,7 +226,7 @@ project_name = {{ identity.project_name }}
 username = {{ identity.username }}
 password = {{ identity.password }}
 {% if ca and ca.bundle -%}
-cafile = {{ snap_common }}/etc/ssl/certs/receive-ca-bundle.pem
+verify_ssl_path = {{ snap_common }}/etc/ssl/certs/receive-ca-bundle.pem
 {% endif -%}
 {% endif -%}
 

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -81,12 +81,17 @@ def test_nova_clients_use_internal_interface():
     assert "[neutron]" in output
     assert "[placement]" in output
     assert "[barbican]" in output
-    assert output.count("interface = internal") >= 4
+    assert output.count("interface = internal") >= 3
+    assert output.count("barbican_endpoint_type = internal") == 1
     assert "region_name = RegionOne" in output
     assert (
         "cafile = /var/snap/openstack-hypervisor/common/etc/ssl/certs/receive-ca-bundle.pem"
         in output
     )
+    assert (
+        "verify_ssl_path = /var/snap/openstack-hypervisor/common/etc/ssl/certs/receive-ca-bundle.pem"
+        in output
+    ) == 1
 
 
 def test_neutron_clients_use_internal_interface():


### PR DESCRIPTION
Use the correct configuration option
with Barbican section to use the certificate
and correct endpoint.

Closes-Bug: LP#2155842