### PR TITLE
snap: derive version from git ref

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: openstack-hypervisor
 version: '2024.1'
+adopt-info: snap-version
 base: core24
 summary: OpenStack Hypervisor
 description: |
@@ -349,6 +350,21 @@ apps:
     install-mode: disable
 
 parts:
+  snap-version:
+    plugin: nil
+    build-packages:
+      - git
+    override-build: |
+      set -eu
+      craftctl default
+      gitref="$(git -C "$CRAFT_PROJECT_DIR" rev-parse --short=8 HEAD)"
+      version="$(craftctl get version)-${gitref}"
+      git -C "$CRAFT_PROJECT_DIR" update-index -q --refresh
+      if ! git -C "$CRAFT_PROJECT_DIR" diff-index --quiet HEAD --; then
+        version="${version}+dirty"
+      fi
+      craftctl set version="${version}"
+
   kvm-support:
     plugin: nil
     stage-packages:


### PR DESCRIPTION
Use snapcraft adopt-info to populate the snap version from the static release version and the current git ref at build time.

Append +dirty when tracked files differ from HEAD so local builds are visibly not from a clean checkout.


(cherry picked from commit 7004a199fca8705c63b3f74eb8c06f457738a160)