### PR TITLE
snap: fix s390x build of wheel-less Python dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,13 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.uv.extra-build-dependencies]
+# On architectures without published wheels (notably s390x), cryptography
+# 41.0.7 is built from sdist. Its setuptools-rust build backend imports
+# pkg_resources, which setuptools >= 81 removed, so constrain the build-time
+# setuptools for this package to a release that still ships pkg_resources.
+cryptography = ["setuptools<81"]
+
 [project]
 name = "openstack-hypervisor"
 version = "2026.1"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -830,6 +830,11 @@ parts:
       - rustc
     stage-packages:
       - python3-venv
+      # Python headers (Python.h) must live in the staged Python tree, because
+      # uv builds the venv from this part's staged interpreter. Needed to build
+      # deps from sdist on architectures without published wheels (e.g. s390x):
+      # cryptography, markupsafe, msgpack, psutil.
+      - libpython3-dev
     after:
       - openstack
       - apache2-webdav


### PR DESCRIPTION
On architectures without published wheels (notably s390x), uv builds cryptography, markupsafe, msgpack and psutil from sdist. Two things broke those source builds:

- Python.h was missing. uv creates its venv from this part's *staged* interpreter, so the headers must be in the staged Python tree; a python3-dev build-package does not reach it. Stage libpython3-dev.
- cryptography 41.0.7's setuptools-rust backend imports pkg_resources, which setuptools >= 81 removed. uv sync ignores UV_BUILD_CONSTRAINT, so pin its build-time setuptools < 81 via [tool.uv.extra-build-dependencies], which uv sync honors.

Verified by a native s390x snapcraft build.