### PR TITLE
snap: fix s390x hypervisor snap packaging

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,6 +113,7 @@ apps:
       - dm-multipath
       - nvme-control
       - iscsi-initiator
+      - mdevctl-config
     # Make sure KillMode=process is set in the resulting systemd unit instead of
     # the default KillMode=control-group to avoid the situation where stopping
     # libvirtd causes the forced power off scenario for all VMs; it also affects
@@ -516,7 +517,7 @@ parts:
       - ninja-build
     autotools-configure-parameters:
       - --enable-system
-      - --target-list=x86_64-softmmu,aarch64-softmmu
+      - --target-list=x86_64-softmmu,aarch64-softmmu,s390x-softmmu
       - --disable-install-blobs
       - --disable-user
       - --disable-linux-user
@@ -749,6 +750,10 @@ parts:
       if [ -f $CRAFT_PART_INSTALL/usr/lib/openvswitch-switch-dpdk/ovs-vswitchd-dpdk ]; then
           mv $CRAFT_PART_INSTALL/usr/lib/openvswitch-switch-dpdk/ovs-vswitchd-dpdk $CRAFT_PART_INSTALL/usr/sbin/ovs-vswitchd
       fi
+      if [ ! -e $CRAFT_PART_INSTALL/usr/sbin/ovs-vswitchd ] && \
+          [ -x $CRAFT_PART_INSTALL/usr/lib/openvswitch-switch/ovs-vswitchd ]; then
+          ln -s ../lib/openvswitch-switch/ovs-vswitchd $CRAFT_PART_INSTALL/usr/sbin/ovs-vswitchd
+      fi
 
   apache2-webdav:
     plugin: nil
@@ -969,6 +974,10 @@ hooks:
       - microstack-support
 
 plugs:
+  mdevctl-config:
+    interface: system-files
+    read:
+      - /etc/mdevctl.d
   epa-info:
     interface: content
     content: epa-info


### PR DESCRIPTION
Enable the snap to run the libvirt/nova-compute stack on s390x by addressing the packaging issues found during LPAR validation.

Build QEMU with the s390x-softmmu target so nova-compute can find a native s390x emulator.

Expose /etc/mdevctl.d to libvirtd through a read-only system-files plug, matching libvirt's mediated-device discovery behaviour.

Create /usr/sbin/ovs-vswitchd as a fallback symlink when the non-DPDK Open vSwitch binary is staged, so ovsdb-server startup can report the OVS version.

These changes are no-ops for existing amd64/arm64 paths except for the fallback symlink guard, which only runs when /usr/sbin/ovs-vswitchd is otherwise missing.

Assisted-by: Codex 5.5