### PR TITLE
fix: update nova-compute notification config for telemetry meters

### DIFF
--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -235,7 +235,8 @@ verify_ssl_path = {{ snap_common }}/etc/ssl/certs/receive-ca-bundle.pem
 driver = messagingv2
 
 [notifications]
-notification_format = versioned
+notify_on_state_change = vm_and_task_state
+notification_format = both
 {%- endif %}
 
 [oslo_messaging_rabbit]


### PR DESCRIPTION
Change `notification_format` from `versioned` to `both` so that Ceilometer receives unversioned notifications on the `notifications` topic and Watcher receives versioned ones on the `versioned_notifications` topic [0][1]. Ceilometer already subscribes to both topics [2]. Add `notify_on_state_change = vm_and_task_state` to enable instance lifecycle notifications like `compute.instance.booting.time`.

[0] - https://docs.openstack.org/watcher/2026.1/configuration/configuring.html#configure-nova-notifications
[1] - https://docs.openstack.org/nova/2026.1/configuration/config.html#notifications.notification_format
[2] - https://opendev.org/openstack/sunbeam-charms/commit/15739a4dbf4245234c2a6348c14654f9c2980156 

Partial-bug: [#2162762](https://bugs.launchpad.net/snap-openstack/+bug/2162762)

## QA steps
1. Deploy sunbeam and enable telemetry
```
sunbeam enable telemetry
```
2. Build and install the openstack-hypervisor snap with this branch
3. Verify nova-compute config
```
grep -A5 oslo_messaging_notifications /var/snap/openstack-hypervisor/common/etc/nova/nova.conf
# [oslo_messaging_notifications]
# driver = messagingv2
#
# [notifications]
# notify_on_state_change = vm_and_task_state
# notification_format = unversioned
```
4. Launch an instance and verify `compute.instance.booting.time` metric
```
openstack server create --flavor m1.small --image ubuntu --network demo-network test-vm
openstack metric resource show <instance-id>
# Should include compute.instance.booting.time (missing without this fix)
```
5. Enable Watcher and verify it receives versioned notifications

## Links
**Jira card:** [OPEN-4670](https://warthogs.atlassian.net/browse/OPEN-4670)

[OPEN-4670]: https://warthogs.atlassian.net/browse/OPEN-4670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ