### PR TITLE
fix: update nova-compute notification config for telemetry meters

### DIFF
--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -235,6 +235,7 @@ verify_ssl_path = {{ snap_common }}/etc/ssl/certs/receive-ca-bundle.pem
 driver = messagingv2
 
 [notifications]
+notify_on_state_change = vm_and_task_state
 notification_format = versioned
 {%- endif %}
 


### PR DESCRIPTION
Add `notify_on_state_change = vm_and_task_state` to enable instance lifecycle notifications like `compute.instance.booting.time`.

Partial-bug: [#2162762](https://bugs.launchpad.net/snap-openstack/+bug/2162762)

<!--
This is a template for pull requests. Please fill out the relevant sections below
and remove all template comments before submitting.
-->

<!--
The PR title should comply with conventional commits: <type>(optional <scope>): <description>

Please also ensure all commits in this PR comply with our conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## QA steps

<!--

Describe how a reviewer can test this change.

-->
1. Deploy sunbeam
2. Build and install the openstack-hypervisor snap with this branch
3. Enable telemetry
```
sunbeam enable telemetry
```
Verify nova-compute config
```
grep -A5 oslo_messaging_notifications /var/snap/openstack-hypervisor/common/etc/nova/nova.conf
[oslo_messaging_notifications]
driver = messagingv2

[notifications]
notify_on_state_change = vm_and_task_state
notification_format = versioned
```
Launch an instance and verify compute.instance.booting.time metric
```
openstack server create --flavor m1.small --image ubuntu --network demo-network test-vm
openstack metric resource show <instance-id>
# Should include compute.instance.booting.time (missing without this fix)
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Place JIRA number in both places below. -->
**Jira card:** [OPEN-](https://warthogs.atlassian.net/browse/OPEN-)
